### PR TITLE
Improve websocket error handling

### DIFF
--- a/solmate.py
+++ b/solmate.py
@@ -12,7 +12,7 @@ import solmate_mqtt as smmqtt
 import solmate_websocket as smws
 
 # version 1.1.1
-# 2023.08.30
+# 2023.08.31
 
 def print_request_response(route, response):
 	# print response in formatted or unformatted json
@@ -79,7 +79,9 @@ def main():
 	except Exception as err:
 		smws.logging('Failed creating connection to websocket class.', console_print)
 		smws.logging(str(err), console_print)
-		sys.exit()
+		# wait until the next try, but do it with a full restart
+		smws.timer_wait(timer_config, 'timer_offline', console_print, True)
+		smws_conn.restart_program()
 
 	# determine if the system is online
 	if 'online' in response:

--- a/solmate_websocket.py
+++ b/solmate_websocket.py
@@ -58,8 +58,8 @@ class connect_to_solmate:
 			# see the readme.md file for a possible reason
 			logging('Websocket is connected to: ' + self.server_uri, self.console_print)
 		except Exception as err:
-			logging('Websockets: ' + str(self.server_uri), self.console_print)
-			logging('Websockets: ' + str(err), self.console_print)
+			logging('Websockets error: ' + str(self.server_uri), self.console_print)
+			logging('Websockets error: ' + str(err), self.console_print)
 			raise
 
 	async def send_api_request(self, data):


### PR DESCRIPTION
Covers the error during authentication, which can happen if there are changes on the backend we have no influence on.

* Without that fix, the script ends.
* With this change, the error is treated properly and the script restarted.

```
Using env file: /home/mmattel/solmate/.env
Initializing websocket connection...
Authenticating...
Websockets: wss://sol.eet.energy:9124/
Websockets: server rejected WebSocket connection: HTTP 502
Failed creating connection to websocket class.
server rejected WebSocket connection: HTTP 502
```