### PR TITLE
Remove envvar 'eet_network' for ease of configuration

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,13 +1,18 @@
+# mqtt config
+mqtt_server=<mqtt-address>
+mqtt_port=1883
+mqtt_username=<mqtt-user>
+mqtt_password=<mqtt-password>
+mqtt_client_id=solmate_mqtt
+mqtt_topic=solmate
+mqtt_prefix=eet
+mqtt_ha=homeassistant
+
 # solmate config
 # get the local domain from your network setup (router, dhcp etc.)
-eet_server_uri="ws://sun2plug.<your-domain>:9124/"
+#eet_server_uri="ws://sun2plug.<your-domain>:9124/"
 
-# 'eet_network' is only necessary when accessing from the local network, in combination with the URI above
-# when the solmate is local, it does not respond with 'online' compared to server access. as long the
-# response does not change, we need that workaround. 
-eet_network='local'
-
-# #eet_server_uri="wss://sol.eet.energy:9124/"
+eet_server_uri="wss://sol.eet.energy:9124/"
 
 eet_serial_number="<solmate-serial-number>"
 eet_password="<solmate-password>"

--- a/README.md
+++ b/README.md
@@ -115,16 +115,22 @@ You can also use envvars instead.
 As a starting point, make a copy of the `.env-sample` file, name it `.env` and adapt it accordingly.
 
 ```
+# mqtt config
+mqtt_server=<mqtt-address>
+mqtt_port=1883
+mqtt_username=<mqtt-user>
+mqtt_password=<mqtt-password>
+mqtt_client_id=solmate_mqtt
+mqtt_topic=solmate
+mqtt_prefix=eet
+mqtt_ha=homeassistant
+
 # solmate config
-# get the local domain from your network setup (router, dhcp etc.)
-eet_server_uri="ws://sun2plug.<your-domain>:9124/"
+# get the local address from your dhcp server
+# note that local access is good for testing, but does currently not seem to be stable
+#eet_server_uri="ws://sun2plug.<your-domain>:9124/"
 
-# 'eet_network' is only necessary when accessing from the local network, in combination with the URI above
-# when the solmate is local, it does not respond with 'online' compared to server access. as long the
-# response does not change, we need that workaround. 
-eet_network='local'
-
-# #eet_server_uri="wss://sol.eet.energy:9124/"
+eet_server_uri="wss://sol.eet.energy:9124/"
 
 eet_serial_number="<solmate-serial-number>"
 eet_password="<solmate-password>"

--- a/solmate.py
+++ b/solmate.py
@@ -85,7 +85,7 @@ def main():
 	# determine if the system is online
 	if 'online' in response:
 		online = response['online']
-	elif solmate_config['eet_network'] == 'local':
+	elif 'sol.eet.energy' in solmate_config['eet_server_uri']:
 		online = True
 	else:
 		online = False


### PR DESCRIPTION
* The envvar `eet_network` is removed, the code now takes care in a better way, easying configuration.
* The `.env-sample` file now also contains the mqtt config parameters.