### PR TITLE
Clarify in .env-sample the use of eet_local_subdomain

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -11,7 +11,10 @@ mqtt_ha=homeassistant
 # use local access if you also want to reboot the solmate.
 # get the local domain from your network setup (router, dhcp etc.)
 # note: MUTUAL EXCLUSIVE to the internet eet_server_uri entry. only one must be enabled.
-# you can also use an IP address like "ws://<solmate-IP-address>:9124/"
+# you can also use an IP address like "ws://<solmate-IP-address>:9124/".
+# if you only have an IP address but would like to know the FQDN, type `nslookup <solmate-IP-address`.
+# if you get a return like `sun2plug.home`, use that one.
+# NOTE that using a FQDN is preferred, as an IP address can change...
 #eet_server_uri="ws://sun2plug.<your-domain>:9124/"
 
 # subdomain for the local solmate dns name, check your (routers) dns entry for the solmate

--- a/.env-sample
+++ b/.env-sample
@@ -8,13 +8,16 @@ mqtt_topic=solmate
 mqtt_prefix=eet
 mqtt_ha=homeassistant
 
-# use local access if you also want to reboot the solmate
+# use local access if you also want to reboot the solmate.
 # get the local domain from your network setup (router, dhcp etc.)
-# note: MUTUAL EXCLUSIVE to the internet eet_server_uri entry. only one must be enabled
+# note: MUTUAL EXCLUSIVE to the internet eet_server_uri entry. only one must be enabled.
+# you can also use an IP address like "ws://<solmate-IP-address>:9124/"
 #eet_server_uri="ws://sun2plug.<your-domain>:9124/"
 
 # subdomain for the local solmate dns name, check your (routers) dns entry for the solmate
-# MUST be populated when using local access. not needed when using the server below
+# MUST be populated when using local access. not needed when using the server below.
+# IMPORTANT: when using an IP address instead an FQDN to access the solmate locally,
+# you MUST replace "sun2plug" with the IP address in quotes like "192.168.1.55".
 eet_local_subdomain="sun2plug"
 
 # needs an internet connection


### PR DESCRIPTION
Fixes: #17 (Solmate offline obwohl online)

The value of `eet_server_uri` when using local access and `eet_local_subdomain` and in `.env-sample` needs clarification to get a FQDN respectively when using an IP address instead a FQDN. 