### PR TITLE
Improve HAOS integration

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -59,3 +59,9 @@ general_console_print='True'
 
 # globally enable/disable mqtt, makes it easier for testing
 general_use_mqtt=True
+
+# API info call only (key can be omittet, not necessary to be present)
+# ONLY use if you want to print the available solmate routes.
+# these routes have been officially added to the API.
+# note that EET sometimes just "forgets" to add new ones to the response list though existing...
+general_api_info=False

--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@ A Python script to read data from a EET SolMate and send it to a MQTT broker for
    * [Preparation and Quick Start](#preparation-and-quick-start)
    * [Preparation for HAOS](#preparation-for-haos)
    * [Script Components](#script-components)
-   * [Error Handling](#error-handling)
-   * [Known Routes](#known-routes)
-   * [Example Calls](#example-calls)
    * [Run as systemd Service (Linux Only)](#run-as-systemd-service-linux-only)
    * [Home Assistant](#home-assistant)
       * [MQTT Sensors](#mqtt-sensors)
@@ -67,7 +64,7 @@ See the [HAOS - solmate](./docs/prep-ha.md) description for details.
 
 ## Script Components
 
-See the [description](./docs/script-components.md) for details.
+See the linked [description](./docs/script-components.md) for details.
 
 ## Run as systemd Service (Linux Only)
 

--- a/crond-execute
+++ b/crond-execute
@@ -3,17 +3,68 @@
 # define the scripts path.
 # DO NOT DELETE or RENAME this variable
 SCRIPT_DIR="/config/shell/solmate"
+LAST_DIR_NAME=$(basename "$SCRIPT_DIR")
 
-#echo "${SCRIPT_DIR}/bin/activate"
-#echo "${SCRIPT_DIR}/solmate.py" "${SCRIPT_DIR}/.env"
-#exit
+count_to_kill() {
+  if [ -z "$1" ]; then
+    # Empty
+    count=0
+  else
+    # Not Empty
+    count=$(wc -l <<< "$1")
+  fi
+  # we only expect numbers
+  echo $count
+}
+
+kill_crond() {
+  # kill running instances of crond related to solmate after n seconds - if found
+  # waiting allows that other potential solmates (not the same ones) can start too
+  # as we are on a 15min track, that shpuld be enough
+  sleep 30 # seconds
+  TO_KILL=$(ps | grep crond | grep "$SCRIPT_DIR" | grep -v grep | sed 's/root.*$//' | sed 's/^[[:space:]]*//g' | grep -v '^$')
+  COUNT=$(count_to_kill "$TO_KILL")
+  if [ "$COUNT" -ne 0 ]; then
+    echo "killing $COUNT running crond"
+    while IFS= read -r LINE
+    do
+      kill -9 "$LINE"
+    done <<< "$TO_KILL"
+  fi
+}
+
+# get the list of running solmate processes for that solmate, one by each line
+# python, script path, no grep, remove everything after ID, remove all spaces, remove empty lines
+TO_KILL=$(ps | grep python | grep "$SCRIPT_DIR" | grep -v grep | sed 's/root.*$//' | sed 's/^[[:space:]]*//g' | grep -v '^$')
+COUNT=$(count_to_kill "$TO_KILL")
+
+# count running processes for that solmate - if any
+# and if exactly one, exit, no need to restart
+if [ "$COUNT" -eq 1 ]; then
+  # already running
+  echo "solmate script aready running"
+  kill_crond
+  exit
+fi
+
+# kill all running solmate processes for that solmate - if more than one is running
+if [ "$COUNT" -gt 1 ]; then
+  echo "killing $COUNT running solmate scripts"
+  while IFS= read -r LINE
+  do
+    kill -9 "$LINE"
+  done <<< "$TO_KILL"
+fi
 
 # activate the python virtual environment
+echo "activating python venv"
 source "${SCRIPT_DIR}/bin/activate"
 
 # run the script
 # python buffers before writing to the output, -u disables that behavior
+echo "starting solmate script"
 nohup python -u "${SCRIPT_DIR}/solmate.py" "${SCRIPT_DIR}/.env" >> "${SCRIPT_DIR}/nohup.log" 2>&1 &
+# for testing purposes only, comment the above and uncomment the below
+#nohup python -u "${SCRIPT_DIR}/test.py" >> "${SCRIPT_DIR}/nohup.log" 2>&1 &
 
-# kill the running instances of crond - if found
-pgrep -x "crond" | xargs -r kill -9
+kill_crond

--- a/crond-prepare
+++ b/crond-prepare
@@ -4,39 +4,43 @@
 # https://community.home-assistant.io/t/how-to-start-crond-automatically-when-restart/236675/2
 
 # get the scripts path
-SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+SCRIPT_DIR=$(dirname $(readlink -f "$0"))
+SCRIPT_DIR_SED=${SCRIPT_DIR//\//\\/}
+LAST_DIR_NAME=$(basename "$SCRIPT_DIR")
 
-# check if an instance of solmate is already running
+# check if a solmate instance from the particular directory is already running
 # avoid to create another instance
-is_running=$(ps | grep python | grep solmate)
+is_running=$(ps | grep python | grep "$SCRIPT_DIR")
 if [[ "$is_running" ]]
 then
   exit
 fi
 
-# overwrite in the execute script the path
+# overwrite the path in the execute script located in SCRIPT_DIR
 # this is necessary as that bash script is then being copied to
 # another location and it needs to know the path to execute the python script
-sed -i "/SCRIPT_DIR=/c\SCRIPT_DIR=\"${SCRIPT_DIR}\" " $SCRIPT_DIR/crond-execute
+sed -i "/SCRIPT_DIR=/c\SCRIPT_DIR=${SCRIPT_DIR_SED}" $SCRIPT_DIR/crond-execute
 
-# delete any occurrences of existing solmate entries in teh crontab/root file
-sed -i "/\/config\/solmate/d" /etc/crontabs/root
+# delete any occurrences of existing solmate entries in the /etc/crontabs/root file
+sed -i "/${SCRIPT_DIR_SED}/d" /etc/crontabs/root
 
-# add a new line to the crontab file including a redirected logoutput
-# this log output is onyl being populated when a startup error of the pythin script occurs
+# add a new line to the /etc/crontabs/root file including a redirected logoutput
+# this log output is onyl being populated when a startup error of the python script occurs
 sed -i "/\*\/15/i\*/2     *       *       *       *       run-parts /etc/periodic/solmate > ${SCRIPT_DIR}/crontabs.log 2>&1" /etc/crontabs/root
 
-# copy the executing script to the target location so it can be
-# processed by crond. the location is not reboot persistant and
-# will be recreated on reboot!
+# copy the executing script to the target location so it can be processed by crond.
+# the location is not reboot persistent and will be recreated on reboot!
 mkdir -p /etc/periodic/solmate
-cp "${SCRIPT_DIR}/crond-execute" /etc/periodic/solmate/
+cp "${SCRIPT_DIR}/crond-execute" /etc/periodic/"$LAST_DIR_NAME"/
 
 rm -f "${SCRIPT_DIR}/crond.log" || true
 rm -f "${SCRIPT_DIR}/crontab.log" || true
 
 # crond should not run
 # https://unix.stackexchange.com/questions/412805/crond-log-level-meaning
+# we cant destinguish if there are more than one solmates configured starting crond.
+# we cant destinguish who has started crond
+# in case, we log all info to the first one that gets started!
 if ! pgrep -x "crond" > /dev/null
 then
   # start crond with loglevel 5

--- a/docs/prep-ha.md
+++ b/docs/prep-ha.md
@@ -2,26 +2,35 @@
 
    * [Important Information](#important-information)
    * [Preparation](#preparation)
+   * [First Test](#first-test)
    * [HA Stuff](#ha-stuff)
    * [Execution Delay](#execution-delay)
    * [Monitoring](#monitoring)
+   * [Updating the Scripts](#updating-the-scripts)
    * [Terminate the Solmate Script](#terminate-the-solmate-script)
    * [Manually Starting the Startup Script](#manually-starting-the-startup-script)
 
 ## Important Information
 
-When running HAOS you **MUST** prepare the environment to autostart the solmate script. Note that this is a bit different than using a dockerized HA with full OS access or a separate host as HAOS does not have any systemd and shell scripts hard stop after 60 seconds. But creativity finds its way...
+* When running HAOS you **MUST** prepare the environment to autostart the solmate script. Note that this is a bit different than using a dockerized HA with full OS access or a separate host as HAOS does not have any systemd and shell scripts hard stop after 60 seconds. But creativity finds its way...
+
+* If you have more than one Solmate, each solmate script with it's configuration must run in its own directory.
+
+* If you run the Mosquitto Broker Addon, any user who is created in HA is granted to access the broker. If you do not want to use the credentials of the admin account for the use with the solmate config, you **MUST** configure a (_dummy_) user and password for the solmate config. If no user is defined in the solmate config or the user used does not exist in HA, you will get a `MQTT connection refused: Not authorized` response and the script will stop. For more information on the user, see\
+`http://<your-HA>:8123/hassio/addon/core_mosquitto/documentation`
+
+* For any _configuration_ changes like creating or editing `.env` or `configuration.yaml`, you can use the Homeassistant SSH Addon like the `Advanced SSH & Web Terminal`. 
 
 ### How It Works
 
-In a nutshell, a shell command is defined pointing to a script that can be used for an automation triggered on
+In a nutshell, a HA shell command is defined pointing to a script that can be used for an automation triggered on
 startup like a reboot. This script prepares the environment by adding a job to crontab and other stuff. It than
 copies another script that gets executed by `crond` (as part of HA's busybox integration) which finally gets started.
 crond is not killed by the shell command time limit (it is a OS service!) and is therefore usable starting
 long running tasks. crontab and other stuff is hard reset by HA on upgrades/reboot and the script takes care not
 writing double entries. After python is executed, crond is killed to guarantee a single run. The procedure recognizes
 an already running solmate script and exits in case. Note that we never know if HA removes crond, but I doubt they
-do so.
+will do so.
 
 ### How to Get HAOS System Access
 
@@ -31,9 +40,22 @@ container, the system does not differ to a standard Linux installation running a
 are looking for.
 
 * For the basic setup, you **MUST NOT USE** any Homeassistant SSH Addon like the `Advanced SSH & Web Terminal`
-These addons have limited access and permissions. Any trial to use it for this purpose will
-simply fail.
+These addons have limited access and permissions. Any trial to use it for this purpose will simply fail.
 * For the configuration, you **CAN** use these terminals after the basic setup has been made.
+
+### Shell Types
+
+There are several shells for different purposes available.
+To not get confused, here is a description.
+
+You recognize easily in which shell (level) you are, based on the shell prompt:
+
+* In the HAOS command console it is: `ha`
+* Outside the Docker container it is: `#` 
+* In Docker, it is e.g.: `homeassistant` 
+
+`ha` --> login --> `#` --> docker exec ... --> `homeassistant`\
+`homeassistant` --> ctrl-d --> `#` --> ctrl-d --> `ha`
 
 ### Prepare Basic Setup
 
@@ -49,8 +71,10 @@ uses an US keyboard layout. If you are not used to it, open an own browser tab t
 
 After you have HAOS system access and your prompt shows `ha >`, you need to do these two steps:
 
-* Login into HAOS via the command `login`.
-* Login into the container with: `docker exec -it homeassistant bash`
+* Login into HAOS via the command `login`.\
+`ha` --> `#`
+* Login into the container with: `docker exec -it homeassistant bash`\
+`#` --> `homeassistant`
 
 Now you are inside the running container where you will do the preperation described in the next step.
 
@@ -60,7 +84,7 @@ After you are in the containers bash, you **MUST** put the scripts into a subfol
 `/config/shell/solmate`. The config directory in the container is the only directory that is not cleaned up on reboot
 or HA update/upgrade.
 
-* Similar to the [standard installation](./prep-standard.md), do:
+* Similar to the [standard installation](./prep-standard.md):
   * Get all source files into `/config/shell` via git clone which is most easiest.
 * Prepare the [Python virtual environment](https://docs.python.org/3/library/venv.html):
   * `cd /config/shell/solmate`
@@ -68,7 +92,7 @@ or HA update/upgrade.
   * `source /config/shell/solmate/bin/activate`  
   (this activates the venv for upcoming tasks)
 * Check that all required modules are installed.  
-     Run `python check_reqirements.py` to see which are missing.  
+     Run `python check_requirements.py` to see which are missing.  
      You may need to cycle thru until all requirements are satisified.
    * [Configure](script-components.md#solmate_envpy) the `.env` file.
 * As a venv "freezes" the python and library versions used, you must take care manually to upgrade it when there
@@ -76,8 +100,23 @@ or HA update/upgrade.
   * The good thing is, that venv setups are reboot pesistent - means on reboot, you do not need to manually
     reinstall libraries.
   * Library upgrades can be done in the usual way for venv environments, for python check the documentation.
-* Check that the two scripts `crond-execute` and `crond-prepare` are executable.  
+* Check that the two scripts `crond-execute` and `crond-prepare` are executable.\
+  Type: `ls -la`, the crond-xxxx scripts should be printed green (respectively marked executable).
   If not run: `chmod +x <script-name>`.
+
+## First Test
+
+If you have configured all from the above, run a test to see if the script starts without issues:
+
+* Change into the solmate directory `cd /config/shell/solmate`
+* Activate the virtual env with `source /config/shell/solmate/bin/activate`
+* Run `python -u solmate.py`
+
+If you get a list of actions printed on the command line ending with\
+`Once a day queries called by scheduler.`\
+you have successfully configured the solmate script.
+
+Finally press `ctrl-c` to end the script. Do not omit this!!
 
 ## HA Stuff
 
@@ -88,16 +127,21 @@ or HA update/upgrade.
   shell_command:
     start_solmate: /config/shell/solmate/crond-prepare
   ```
+  Reboot HA\
+  **Mandatory**, else the shell command will not get recognized.
+
 * Create an [automation](https://www.home-assistant.io/getting-started/automation/) by defining:
   * IF: `Home Assistant is started`
   * EXECUTE: `Call a service` ==> `start_solmate`
+
 * You will now see your automation in the list.
+
 * For testing, change to the HA development page to services and select `Shell Command: start_solmate`.
 
 ## Execution Delay
 
 When `crond-prepare` gets started, it takes between 3 and 5 minutes that crond finally executes `crond-execute`.
-This is normal and expected. If interested, you can monitor the progress with `tail -f crond.log`.
+This is normal and expected. If interested, you can monitor the progress with `tail -f crond.log` respectively `tail -f crontabs.log`. The files are created in the solmate directory.
 
 ## Monitoring
 
@@ -124,9 +168,13 @@ be added to the normal HA logs by design. Note that cron logs are deleted on sta
   If this file becomes too big (not likely but can happen on a long rung), it is safe to remove it when
   `solmate.py` is NOT running. It gets recreated on startup. New data is appended.
 
+## Updating the Scripts
+
+To update the scripts, follow the instructions in the update item in the [Standard Preparation](../docs/prep-standard.md#standard-preparation). To restart the script, you must first terminate the existing one, see section below. Then you can either manually start it, see below or trigger the script start via the HA automation.
+
 ## Terminate the Solmate Script
  
-If you want to end the solmate script, do the following in a HAOS terminal:
+If you want to terminate the solmate script started via crond, do the following in a HAOS terminal:
 
 * Run `ps` and remember the number at the beginning of the `python solmate.py` line.
 * Type `kill -9 <number>` and the process gets killed.
@@ -138,3 +186,5 @@ If you need to test or want to start the script via the terminal - on your own r
 
 * Check and adapt the `SCRIPT_DIR` location in `crond-execute`.
 * `./crond-execute` from the location where the script is stored.
+
+Alternatively you can run `./crond-prepare` if you want to include the test using crond execution.

--- a/docs/prep-standard.md
+++ b/docs/prep-standard.md
@@ -9,6 +9,8 @@ This section is valid when running a dockerized HA or when using a separate host
     ```
     git clone --depth 1 https://github.com/mmattel/eet-solmate.git solmate
     git fetch --all --tags
+    git ls-files
+    ls -la
     ```
   * Use the following commands **for updates**:  
     Note that this will drop any changes made except configuration.  
@@ -18,6 +20,8 @@ This section is valid when running a dockerized HA or when using a separate host
     git stash -u && git stash drop
     git pull --rebase origin main
     git fetch --all --tags
+    git ls-files
+    ls -la
     ```
   * Switch to a stable solmate version (example v4.0.0):
     ```

--- a/docs/script-components.md
+++ b/docs/script-components.md
@@ -7,6 +7,9 @@
    * [`solmate_check.py`](#solmate_checkpy)
    * [`solmate_env.py`](#solmate_envpy)
       * [Necessary Data in the '.env' File](#necessary-data-in-the-env-file)
+   * [Error Handling](#error-handling)
+   * [Known Routes](#known-routes)
+   * [Example Calls](#example-calls)
 
 ## solmate.py
 
@@ -93,6 +96,8 @@ Following parameters are intended either for development or testing but feel fre
 * Define `general_console_print` to enable logging using console additionally, syslog is always used.
 
 * Define `general_use_mqtt` to globally enable/disable mqtt, makes it easier for testing.
+
+Note that the environment variable `general_api_info` only needs to be present and set to true if one wants to request a list of known routes requested via the `get_api_info` route. You can see the output at [Known Routes](#known-routes). Note that EET sometimes "forgets" to add new routes to the API list, which is quite painful to reverse engineer. A difference can be seen like when opening a browser to set/request data on the Solmate and new items appear but are not listed in the API response. 
 
 ## Error Handling
 

--- a/solmate.py
+++ b/solmate.py
@@ -115,6 +115,15 @@ def main():
 		utils.timer_wait(merged_config, 'timer_offline', console_print, True)
 		utils.restart_program(console_print)
 
+	# check if we should *only* print the current API info response
+	if 'general_api_info' in merged_config.keys():
+		# if the api_info key is present check for True:
+		if merged_config['general_api_info'] == 'True':
+			response = smws_conn.query_solmate('get_api_info', {}, merged_config)
+			print('\n\'get_api_info\' route info requested: \n')
+			print(json.dumps(response, ensure_ascii=False, indent=2, separators=(',', ': ')))
+			sys.exit()
+
 	if use_mqtt:
 		# initialize and start mqtt
 		mqtt = smmqtt.solmate_mqtt(merged_config, smws_conn, local, console_print)

--- a/solmate_websocket.py
+++ b/solmate_websocket.py
@@ -177,7 +177,7 @@ class connect_to_solmate:
 			utils.logging('Authentication failed!', self.console_print)
 			raise
 
-	def query_solmate(self, route, value, merged_config, mqtt):
+	def query_solmate(self, route, value, merged_config, mqtt = False):
 		# send request for the given route including error handling
 
 		try: 

--- a/test.py
+++ b/test.py
@@ -1,0 +1,6 @@
+# this script does nothing and is intended for testing purposes only
+import time
+
+while True:
+	time.sleep(10)
+	pass


### PR DESCRIPTION
This PR mainly improves the HAOS integration:

* Update and fix README and docs related documents.
* Add a new optional envvar `general_api_info` with which you can query the solmates API for defined routes. Helps to identify API changes (or additions) more easily.
* Add a MQTT disconnect reason printout like:
`MQTT disconnected: Unspecified error, packet: Disconnect`
* MQTT now subscribes after a successful connection.
This also takes place when there is a dis- and automatic reconnect.
* Fixing MQTT error messaging when missing credentials are given but HA requires them.
* Update the `crond-xxx` files to improve HAOS handling.
This now checks that only one instance of the particular solmate script is running.
Fix paths for sed find and replace.
* Make the `crond-xxx` files executable by default, eases installation for HAOS.

Tested with a local test instance of HAOS. Runs fine.