### PR TITLE
Replace deprecated pgk_resources module (non breaking)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ datetime
 ##json
 ##os
 ##queue
-##pkg_resources
 paho-mqtt
 python-dotenv
 semver

--- a/solmate_check.py
+++ b/solmate_check.py
@@ -1,19 +1,18 @@
-import pkg_resources
 import semver
 import solmate_utils as utils
 import sys
-
-# https://stackoverflow.com/questions/31304041/how-to-retrieve-pip-requirements-freeze-within-python
+from importlib import metadata
 
 def package_version(console_print):
-    installed = {pkg.key: pkg.version for pkg in pkg_resources.working_set}
+	# https://discuss.python.org/t/the-fastest-way-to-make-a-list-of-installed-packages/23175/4
+	# note that due to a "bug" in the importlib version in python 3.9,
+	# we cant list installed packages, we can only query them if known.
 
-    # check that the package version of the paho-mqtt library is major version 2
+	# check that the package version of the paho-mqtt library is major version 2
 	# because of breaking changes from 1 --> 2
-    version = semver.Version.parse(installed['paho-mqtt'])
-    if version.major != 2:
-        utils.logging('The paho-mqtt client must be major version 2, check the requirements in README.md, exiting.', console_print)
-        sys.exit()
+	version = semver.Version.parse(metadata.version('paho-mqtt'))
+	if version.major != 2:
+		utils.logging('The paho-mqtt client must be major version 2, check the requirements in README.md, exiting.', console_print)
+		sys.exit()
 
-# if required, add other package queries
-
+	# if required, add other package version queries


### PR DESCRIPTION
References: #43 

This PR replaces the `pgk_resources` module which got deprecated in Python 3.12.

Existing installations are not affected when they upgrade to the next release containing this fix as the deprecated module will live much longer than I will need for the new version 🤣 