### PR TITLE
[Major] Enable values to be set

### DIFF
--- a/docs/script-components.md
+++ b/docs/script-components.md
@@ -9,7 +9,6 @@
       * [Necessary Data in the '.env' File](#necessary-data-in-the-env-file)
    * [Error Handling](#error-handling)
    * [Known Routes](#known-routes)
-   * [Example Calls](#example-calls)
 
 ## solmate.py
 
@@ -123,65 +122,32 @@ This is informational only and possibly not complete. All routes have as data `{
 3. `live_values`
 4. `get_user_settings`
 5. `get_grid_mode`
-6. `get_injection_settings`  
-  Note that you must provide proper data as attribute, see `get_api_info` output for more details.
-7. `logs`  
+6. `get_injection_settings`\
+  Note that you must provide proper data as attribute, see `get_api_info` output for more details.\
+  Note that there are also writable routes to set injection settings which are not explicitly mentioned here, see `get_api_info` for more details.
+
+7. `logs`\
   Note that you must provide proper data as attribute, see `get_api_info` output for more details.
 9. `shutdown`  
-  This route has a data attribute like `{'shut_reboot': 'reboot'}`
+  This route has the following data attributes\
+  `{'shut_reboot': 'reboot'}`  (used)\
+  `{'shut_reboot': 'shutdown'}` (not used)
 10. `set_system_time`  
   This route has a data attribute like `{datetime: n}` where  
   `const e = On()()`, `n = e.utc().format(t)` and `t = "YYYY-MM-DDTHH:mm:ss"` (using javascript as base)
-
-## Example Calls
-
-These are examples if you want to adapt the code on your own.
-
-```
-	# example data when using the logs route
-	logs_data = {"timeframes": [
-						{
-							"start": "2023-08-18T10:00:00",
-							"end": "2023-08-18T23:59:59",
-							"resolution": 4
-						}
-					]
-				}
-
-	# get a solmate logs, call eg. one a day
-	# query_solmate(route, value, timer_config, mqtt)
-	response = smc_conn.query_solmate('logs', logs_data, timer_config, mqtt)
-	if response != False:
-		if not 'timestamp' in response:
-			# fake a timestamp into the response if not present
-			response['timestamp'] = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
-		# add mqtt or other stuff here
-		if printing:
-			print_request_response('logs', response)
-```
-
-```
-	# get the solmate info, as often you call the block
-	# query_solmate(route, value, timer_config, mqtt)
-	response = smc_conn.query_solmate(route, data, timer_config, mqtt)
-	if response != False:
-		if not 'timestamp' in response:
-			# fake a timestamp into the response if not present
-			response['timestamp'] = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
-		# add mqtt or other stuff here
-		if printing:
-			print_request_response(route, response)
-```
-
-```
-	# loop to continuosly request live values
-	while True:
-		# query_solmate(route, value, timer_config, mqtt)
-		response = smc.query_solmate('live_values', {}, timer_config, mqtt)
-		if response != False:
-			# add mqtt or other stuff here
-			if printing:
-				print_request_response(route, response)
-			# and wait for the next round
-			smc.timer_wait(timer_config, 'timer_live', False)
-```
+11. `get_boost_injection`\
+  This route is not officially documented (part of the get_api_info) but available via the browser.
+    ```yaml
+    {
+      "set_time": 0,
+      "remaining_time": 0,
+      "set_wattage": 500.0,
+      "actual_wattage": 112.59259033203125
+    }
+    ```
+12. `set_boost_injection`\
+  The opposite of `set_boost_injection` but with two key that MUST be written in one request!\
+  Note that EET's original webUI implementation limits the wattage to 500 (I set the limit to 800)
+    ```yaml
+    {"time": 600, wattage: 500}
+    ``` 

--- a/solmate_ha_config.py
+++ b/solmate_ha_config.py
@@ -1,0 +1,773 @@
+import json
+
+# the ha config setup is quite big so it is defined in an own file making mqtt better readable.
+# the init parameters from 'self' are handed over and used as 'c_s'
+
+def construct_ha_config_message(c_s):
+
+	# it is EXTREMELY important to have the correct component set so that HA does the correct thing
+	#
+	# <discovery_prefix>/<component>/[<node_id>/]<object_id>/config|availability|state
+	# c_s.mqtt_config_topic + names[i] + '/config'
+	# https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery
+	# https://www.home-assistant.io/integrations/sensor.mqtt/
+	# https://www.home-assistant.io/integrations/sensor/#device-class
+	# https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes
+	# https://www.home-assistant.io/docs/configuration/customizing-devices/#icon
+
+	names = ['']			# assembled as '/' + virtual_topic + fake_name
+	fake_names = ['']		# the name used in the mqtt message
+	real_names = ['']		# the name used for the solmate API to get/set values
+							# real/fake names can be different !
+							# for automatic status updates, names in different topics must be identical
+							# some naming differences take place like for 'set_user_maximum_injection'
+							# technically this mapping is only necessary for writable keys 
+	route = ['']			# the route for writable entities, needed for the solmate API
+	configs = ['']			# the assembled config for each entry
+	config_topics = ['']	# the topic for HA auto-config
+
+	# note that device_values must be populated
+	device_values = {}
+	device_values['identifiers'] = c_s.merged_config['mqtt_topic'] + '_' + c_s.merged_config['eet_serial_number'] # ['eet_solmate']
+	device_values['name'] = c_s.merged_config['mqtt_topic'] #'SOLMATE'
+	device_values['model'] = 'SOLMATE G'
+	device_values['manufacturer'] = 'EET Energy'
+	device_values['serial_number'] = c_s.merged_config['eet_serial_number']
+
+	# virtual topics
+	live = '/live'
+	live_n = 'live_'
+	info = '/info'
+	info_n = 'info_'
+	button = '/button'
+	button_n = 'button_'
+	get_injection ='/get_injection'
+	get_injection_n = 'get_injection_'
+	get_boost = '/get_boost'
+	get_boost_n = 'get_boost_'
+	set_boost = '/set_boost'
+	set_boost_n = 'set_boost_'
+	set_inject = '/set_inject'
+	set_inject_n = 'set_inject_'
+	dictionaries = {}
+
+# route: 'live_values'
+# collection of live data. queried in relative short intervals
+	i = 0
+	route[i] = False
+	fake_names[i] = 'timestamp'
+	real_names[i] = 'timestamp'
+	name = live_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_sensor_config_topic
+	dictionaries[name] = {
+		'name': name,
+		# give the entiy a better identifyable name for the UI (timestamp is multiple present)
+		# dont use a timestamp class, we manually generate it and manually define the icon
+		'state_topic': c_s.mqtt_sensor_topic + live,
+		'value_template': '{{ (value_json.' + fake_names[i] + " | as_timestamp()) | timestamp_custom('%Y-%m-%d %H:%M:%S') }}",
+		'availability_topic': c_s.mqtt_availability_topic,
+		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'device': device_values,
+		'icon': 'mdi:progress-clock',
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+	i += 1
+	route.append(1)
+	names.append(1)
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	route[i] = False
+	fake_names[i] = 'pv_power'
+	real_names[i] = 'pv_power'
+	name = live_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_sensor_config_topic
+	dictionaries[name] = {
+		'name': name,
+		'device_class': 'power',
+		'state_topic': c_s.mqtt_sensor_topic + live,
+		'value_template': '{{ (value_json.' + fake_names[i] + ' | float(0)) | round(1) }}',
+		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'availability_topic': c_s.mqtt_availability_topic,
+		'unit_of_measurement': 'W',
+		'device': device_values,
+		'icon': 'mdi:solar-power-variant-outline',
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+	i += 1
+	route.append(1)
+	names.append(1)
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	route[i] = False
+	fake_names[i] = 'inject_power'
+	real_names[i] = 'inject_power'
+	name = live_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_sensor_config_topic
+	dictionaries[name] = {
+	'name': name,
+	'device_class': 'power',
+	'state_topic': c_s.mqtt_sensor_topic + live,
+	'value_template': '{{ (value_json.' + fake_names[i] + ' | float(0)) | round(1) }}',
+	'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+	'availability_topic': c_s.mqtt_availability_topic,
+	'unit_of_measurement': 'W',
+	'device': device_values,
+	'icon': 'mdi:transmission-tower-import',
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+	i += 1
+	route.append(1)
+	names.append(1)
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	route[i] = False
+	fake_names[i] = 'battery_flow'
+	real_names[i] = 'battery_flow'
+	name = live_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_sensor_config_topic
+	dictionaries[name] = {
+		'name': name,
+		'device_class': 'power',
+		'state_topic': c_s.mqtt_sensor_topic + live,
+		'value_template': '{{ (value_json.' + fake_names[i] + ' | float(0)) | round(1) }}',
+		'unique_id':c_s.merged_config['eet_serial_number'] + '_' + name,
+		'availability_topic': c_s.mqtt_availability_topic,
+		'unit_of_measurement': 'W',
+		'device': device_values,
+		'icon': 'mdi:home-battery-outline',
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+	i += 1
+	route.append(1)
+	names.append(1)
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	route[i] = False
+	fake_names[i] = 'battery_state'
+	real_names[i] = 'battery_state'
+	name = live_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_sensor_config_topic
+	dictionaries[name] = {
+		'name': name,
+		'state_topic': c_s.mqtt_sensor_topic + live,
+		'value_template': '{{ ((value_json.' + fake_names[i] + ' | float(0)) * 100) | round(1) }}',
+		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'availability_topic': c_s.mqtt_availability_topic,
+		'unit_of_measurement': '%',
+		'device': device_values,
+		'icon': 'mdi:battery-high',
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+	i += 1
+	route.append(1)
+	names.append(1)
+	route[i] = False
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	fake_names[i] = 'temperature'
+	real_names[i] = 'temperature'
+	name = live_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_sensor_config_topic
+	dictionaries[name] = {
+		'name': name,
+		'device_class': 'temperature',
+		'state_topic': c_s.mqtt_sensor_topic + live,
+		'value_template': '{{ (value_json.' + fake_names[i] + ' | float(0)) | round(1) }}',
+		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'availability_topic': c_s.mqtt_availability_topic,
+		'unit_of_measurement': '°C',
+		'device': device_values,
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+	i += 1
+	route.append(1)
+	names.append(1)
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	route[i] = False
+	fake_names[i] = 'mppOutI'
+	real_names[i] = 'mppOutI'
+	name = live_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_sensor_config_topic
+	dictionaries[name] = {
+		'name': name,
+		'device_class': 'current',
+		'state_topic': c_s.mqtt_sensor_topic + live,
+		'value_template': '{{ (value_json.' + fake_names[i] + ' | float(0)) | round(2) }}',
+		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'availability_topic': c_s.mqtt_availability_topic,
+		'device': device_values,
+		'unit_of_measurement': 'A',
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+# route: 'get_solmate_info'
+# collection of info data like SW version. queried like once a day 
+	i += 1
+	route.append(1)
+	names.append(1)
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	route[i] = False
+	fake_names[i] = 'version'
+	real_names[i] = 'version'
+	name = info_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_sensor_config_topic
+	dictionaries[name] = {
+		'name': name,
+		# no device class here as it is a string
+		'state_topic': c_s.mqtt_sensor_topic + info,
+		'value_template': '{{ value_json.' + fake_names[i] + ' | version }}',
+		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'availability_topic': c_s.mqtt_availability_topic,
+		'device': device_values,
+		'entity_category': 'diagnostic',
+		'icon': 'mdi:text-box-outline',
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+	i += 1
+	route.append(1)
+	names.append(1)
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	route[i] = False
+	fake_names[i] = 'ip'
+	real_names[i] = 'ip'
+	name = info_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_sensor_config_topic
+	dictionaries[name] = {
+		'name': name,
+		# no device class here as it is a string
+		'state_topic': c_s.mqtt_sensor_topic + info,
+		'value_template': '{{ value_json.' + fake_names[i] + ' }}',
+		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'availability_topic': c_s.mqtt_availability_topic,
+		'device': device_values,
+		'entity_category': 'diagnostic',
+		'icon': 'mdi:ip-outline',
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+	i += 1
+	route.append(1)
+	names.append(1)
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	route[i] = False
+	fake_names[i] = 'timestamp'
+	real_names[i] = 'timestamp'
+	name = info_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_sensor_config_topic
+	dictionaries[name] = {
+		'name': name,
+		# give the entiy a better identifyable name for the UI (timestamp is multiple present)
+		# dont use a timestamp class, we manually generate it and manually define the icon
+		'state_topic': c_s.mqtt_sensor_topic + info,
+		'value_template': '{{ (value_json.' + fake_names[i] + " | as_timestamp()) | timestamp_custom('%Y-%m-%d %H:%M:%S') }}",
+		'availability_topic': c_s.mqtt_availability_topic,
+		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'device': device_values,
+		'entity_category': 'diagnostic',
+		'icon': 'mdi:clock-time-ten',
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+	i += 1
+	route.append(1)
+	names.append(1)
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	route[i] = False
+	fake_names[i] = 'operating_state'
+	real_names[i] = 'operating_state'
+	name = info_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_sensor_config_topic
+	dictionaries[name] = {
+		'name': name,
+		# no device class here as it is a string
+		'state_topic': c_s.mqtt_sensor_topic + info,
+		'value_template': '{{ value_json.' + fake_names[i] + ' }}',
+		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'availability_topic': c_s.mqtt_availability_topic,
+		'device': device_values,
+		'entity_category': 'diagnostic',
+		'icon': 'mdi:power-settings',
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+	i += 1
+	route.append(1)
+	names.append(1)
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	route[i] = False
+	fake_names[i] = 'connected_to'
+	real_names[i] = 'connected_to'
+	name = info_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_sensor_config_topic
+	dictionaries[name] = {
+		'name': name,
+		# no device class here as it is a string
+		'state_topic': c_s.mqtt_sensor_topic + info,
+		'value_template': '{{ value_json.' + fake_names[i] + ' }}',
+		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'availability_topic': c_s.mqtt_availability_topic,
+		'device': device_values,
+		'entity_category': 'diagnostic',
+		'icon': 'mdi:lan-connect',
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+# collection of system switches like reboot
+# add all switches/buttons here to be part of the system hierarchy
+	if c_s.disabled_api['local']:
+		dynamic_topic = c_s.mqtt_availability_topic
+	else:
+		dynamic_topic = c_s.mqtt_never_available_topic
+	i += 1
+	route.append(1)
+	names.append(1)
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	route[i] = False
+	fake_names[i] = 'reboot'
+	real_names[i] = 'reboot'
+	name = button_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_button_config_topic
+	dictionaries[name] = {
+		'name': name,
+		'command_topic': c_s.mqtt_button_topic + '/command/' + fake_names[i],
+		'availability_topic': dynamic_topic,
+		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'value_template': '{{ value_json.' + fake_names[i] + ' }}',
+		'device': device_values,
+		'entity_category': 'config',
+		'device_class': 'restart',
+		'payload_press': 'doit',
+		'qos': c_s.mqtt_qos,
+		'retain': False
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+# route: 'get_injection_settings'
+# collection of existing injection settings, queried in the same interval of live values 
+	i += 1
+	route.append(1)
+	names.append(1)
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	route[i] = False
+	fake_names[i] = 'user_minimum_injection'
+	real_names[i] = 'user_minimum_injection'
+	name = get_injection_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_sensor_config_topic
+	dictionaries[name] = {
+		'name': name,
+		'device_class': 'power',
+		'state_topic': c_s.mqtt_sensor_topic + get_injection,
+		'value_template': '{{ (value_json.' + fake_names[i] + ' | float(0)) | round(1) }}',
+		'unique_id':c_s.merged_config['eet_serial_number'] + '_' + name,
+		'availability_topic': c_s.mqtt_availability_topic,
+		'unit_of_measurement': 'W',
+		'device': device_values,
+		'icon': 'mdi:home-lightning-bolt-outline',
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+	i += 1
+	route.append(1)
+	names.append(1)
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	route[i] = False
+	fake_names[i] = 'user_maximum_injection'
+	real_names[i] = 'user_maximum_injection'
+	name = get_injection_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_sensor_config_topic
+	dictionaries[name] = {
+		'name': name,
+		'device_class': 'power',
+		'state_topic': c_s.mqtt_sensor_topic + get_injection,
+		'value_template': '{{ (value_json.' + fake_names[i] + ' | float(0)) | round(1) }}',
+		'unique_id':c_s.merged_config['eet_serial_number'] + '_' + name,
+		'availability_topic': c_s.mqtt_availability_topic,
+		'unit_of_measurement': 'W',
+		'device': device_values,
+		'icon': 'mdi:home-lightning-bolt',
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+	i += 1
+	route.append(1)
+	names.append(1)
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	route[i] = False
+	fake_names[i] = 'user_minimum_battery_percentage'
+	real_names[i] = 'user_minimum_battery_percentage'
+	name = get_injection_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_sensor_config_topic
+	dictionaries[name] = {
+		'name': name,
+		'state_topic': c_s.mqtt_sensor_topic + get_injection,
+		'value_template': '{{ ((value_json.' + fake_names[i] + ' | float(0)) | round(1)) }}',
+		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'availability_topic': c_s.mqtt_availability_topic,
+		'unit_of_measurement': '%',
+		'device': device_values,
+		'icon': 'mdi:battery-low',
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+# route: 'get_boost_injection'
+# collection of existing boost injection settings, queried in the same interval of live values 
+	i += 1
+	route.append(1)
+	names.append(1)
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	route[i] = False
+	fake_names[i] = 'set_time'
+	real_names[i] = 'set_time'
+	name = get_boost_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_sensor_config_topic
+	dictionaries[name] = {
+		'name': name,
+		'state_topic': c_s.mqtt_sensor_topic + get_boost,
+		'value_template': '{{ (value_json.' + fake_names[i] + ' | int(0)) }}',
+		'availability_topic': c_s.mqtt_availability_topic,
+		'unit_of_measurement': 's',
+		# the name used can be read and written, so we need to distinguish
+		'unique_id':c_s.merged_config['eet_serial_number'] + '_read_' + name,
+		'device': device_values,
+		'icon': 'mdi:timer-play-outline',
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+	i += 1
+	route.append(1)
+	names.append(1)
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	route[i] = False
+	fake_names[i] = 'set_wattage'
+	real_names[i] = 'set_wattage'
+	name = get_boost_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_sensor_config_topic
+	dictionaries[name] = {
+		'name': name,
+		'device_class': 'power',
+		'state_topic': c_s.mqtt_sensor_topic + get_boost,
+		'value_template': '{{ (value_json.' + fake_names[i] + ' | float(0)) | round(1) }}',
+		# the name used can be read and written, so we need to distinguish
+		'unique_id':c_s.merged_config['eet_serial_number'] + '_read_' + name,
+		'availability_topic': c_s.mqtt_availability_topic,
+		'unit_of_measurement': 'W',
+		'device': device_values,
+		'icon': 'mdi:home-lightning-bolt',
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+	i += 1
+	route.append(1)
+	names.append(1)
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	route[i] = False
+	fake_names[i] = 'remaining_time'
+	real_names[i] = 'remaining_time'
+	name = get_boost_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_sensor_config_topic
+	dictionaries[name] = {
+		'name': name,
+		'state_topic': c_s.mqtt_sensor_topic + get_boost,
+		'value_template': '{{ value_json.' + fake_names[i] + ' | int(0) }}',
+		'availability_topic': c_s.mqtt_availability_topic,
+		'unit_of_measurement': 's',
+		'unique_id':c_s.merged_config['eet_serial_number'] + '_' + name,
+		'device': device_values,
+		'icon': 'mdi:av-timer',
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+	i += 1
+	route.append(1)
+	names.append(1)
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	route[i] = False
+	fake_names[i] = 'actual_wattage'
+	real_names[i] = 'actual_wattage'
+	name = get_boost_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_sensor_config_topic
+	dictionaries[name] = {
+		'name': name,
+		'device_class': 'power',
+		'state_topic': c_s.mqtt_sensor_topic + get_boost,
+		'value_template': '{{ (value_json.' + fake_names[i] + ' | float(0)) | round(1) }}',
+		'unique_id':c_s.merged_config['eet_serial_number'] + '_' + name,
+		'availability_topic': c_s.mqtt_availability_topic,
+		'unit_of_measurement': 'W',
+		'device': device_values,
+		'icon': 'mdi:transmission-tower-import',
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+# collection of user definable values like min/maximum_injection and minimum_battery_percentage etc
+# boost
+	if c_s.disabled_api['sun2plugHasBoostInjection']:
+		dynamic_topic = c_s.mqtt_availability_topic
+	else:
+		dynamic_topic = c_s.mqtt_never_available_topic
+	i += 1
+	route.append(1)
+	names.append(1)
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	route[i] = 'set_boost_injection'
+	fake_names[i] = 'set_wattage'
+	real_names[i] = 'wattage'
+	name = set_boost_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_number_config_topic
+	dictionaries[name] = {
+		'name': name,
+		'entity_category': 'config',
+		'max': 800,
+		'min': 0,
+		'step': 5,
+		'mode': 'slider',
+		'state_topic': c_s.mqtt_sensor_topic + get_boost,
+		'device_class': 'power',
+		'command_topic': c_s.mqtt_number_topic + '/' + fake_names[i],
+		'value_template': '{{ value_json.' + fake_names[i] + ' | int(0) }}',
+		'unique_id':c_s.merged_config['eet_serial_number'] + '_' + name,
+		'availability_topic': dynamic_topic,
+		'unit_of_measurement': 'W',
+		'device': device_values,
+		'icon': 'mdi:home-plus-outline',
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+	i += 1
+	route.append(1)
+	names.append(1)
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	route[i] = 'set_boost_injection'
+	fake_names[i] = 'set_time'
+	real_names[i] = 'time'
+	name = set_boost_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_number_config_topic
+	dictionaries[name] = {
+		'name': name,
+		'entity_category': 'config',
+		'max': 10800, # 3h
+		'min': 0,
+		'step': 60,
+		'mode': 'slider',
+		'state_topic': c_s.mqtt_sensor_topic + get_boost,
+		'command_topic': c_s.mqtt_number_topic + '/' + fake_names[i],
+		'value_template': '{{ value_json.' + fake_names[i] + ' | int(0) }}',
+		'unique_id':c_s.merged_config['eet_serial_number'] + '_' + name,
+		'availability_topic': dynamic_topic,
+		'unit_of_measurement': 's',
+		'device': device_values,
+		'icon': 'mdi:home-clock-outline',
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+# inject
+	i += 1
+	route.append(1)
+	names.append(1)
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	route[i] = 'set_user_minimum_injection'
+	fake_names[i] = 'user_minimum_injection'
+	real_names[i] = 'injection'
+	name = set_inject_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_number_config_topic
+	dictionaries[name] = {
+		'name': name,
+		'entity_category': 'config',
+		'max': 800,
+		'min': 0,
+		'step': 5,
+		'mode': 'slider',
+		'state_topic': c_s.mqtt_sensor_topic + get_injection, 
+		'device_class': 'power',
+		'command_topic': c_s.mqtt_number_topic + '/' + fake_names[i],
+		'value_template': '{{ value_json.' + fake_names[i] + ' | int(0) }}',
+		'unique_id':c_s.merged_config['eet_serial_number'] + '_' + name,
+		'availability_topic': c_s.mqtt_availability_topic,
+		'unit_of_measurement': 'W',
+		'device': device_values,
+		'icon': 'mdi:priority-low',
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+	i += 1
+	route.append(1)
+	names.append(1)
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	route[i] = 'set_user_maximum_injection'
+	fake_names[i] = 'user_maximum_injection'
+	real_names[i] = 'injection'
+	name = set_inject_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_number_config_topic
+	dictionaries[name] = {
+		'name': name,
+		'entity_category': 'config',
+		'max': 800,
+		'min': 0,
+		'step': 5,
+		'mode': 'slider',
+		'state_topic': c_s.mqtt_sensor_topic + get_injection, 
+		'device_class': 'power',
+		'command_topic': c_s.mqtt_number_topic + '/' + fake_names[i],
+		'value_template': '{{ value_json.' + fake_names[i] + ' | int(0) }}',
+		'unique_id':c_s.merged_config['eet_serial_number'] + '_' + name,
+		'availability_topic': c_s.mqtt_availability_topic,
+		'unit_of_measurement': 'W',
+		'device': device_values,
+		'icon': 'mdi:priority-high',
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+	i += 1
+	route.append(1)
+	names.append(1)
+	fake_names.append(1)
+	real_names.append(1)
+	configs.append(1)
+	config_topics.append(1)
+	route[i] = 'set_user_minimum_battery_percentage'
+	fake_names[i] = 'user_minimum_battery_percentage'
+	real_names[i] = 'battery_percentage'
+	name = set_inject_n + fake_names[i]
+	names[i] = '/' + name
+	config_topics[i] = c_s.mqtt_number_config_topic
+	dictionaries[name] = {
+		'name': name,
+		'entity_category': 'config',
+		'max': 90,
+		'min': 0,
+		'step': 5,
+		'mode': 'slider',
+		'state_topic': c_s.mqtt_sensor_topic + get_injection, 
+		'command_topic': c_s.mqtt_number_topic + '/' + fake_names[i],
+		'value_template': '{{ value_json.' + fake_names[i] + ' | int(0) }}',
+		'unique_id':c_s.merged_config['eet_serial_number'] + '_' + name,
+		'availability_topic': c_s.mqtt_availability_topic,
+		'unit_of_measurement': '%',
+		'device': device_values,
+		'icon': 'mdi:battery-low',
+		'retain': True
+	}
+	configs[i] = json.dumps(dictionaries[name])
+
+	# json_formatted_str = json.dumps(dictionaries[name], indent=2, ensure_ascii = False)
+	# print(json_formatted_str)
+
+	return fake_names, real_names, route, names, configs, config_topics

--- a/solmate_utils.py
+++ b/solmate_utils.py
@@ -7,8 +7,11 @@ import time
 
 # functions here are provided for general availability
 
-# create a new queue which is used from all importing modules
-mqueue = queue.Queue()
+# create a new queue which can be accessed from all importing modules
+# we use it for the communication between mqtt and the main loop
+# each element contains a tuple (route, key, value), set by mqtt on message recieved
+# this defines updates to be sent to solmate 
+mqtt_queue = queue.Queue()
 
 # this is just a preparation if the the deprecation would pop up, but has currently NO
 # effect and uses the default method of asyncio.get_event_loop()
@@ -55,8 +58,8 @@ async def _async_timer(timer_value):
 def timer_wait(merged_config, timer_name, console_print, add_log = True, mqtt_command = False):
 	# wait the number of seconds passed via the name as argument
 
-	# mqueue is defined on the module level
-	global mqueue
+	# mqtt_queue is defined on the module level
+	global mqtt_queue
 
 	if add_log:
 		# log at all, but decide where
@@ -70,9 +73,9 @@ def timer_wait(merged_config, timer_name, console_print, add_log = True, mqtt_co
 	for x in range(merged_config[timer_name] * 2):
 		# check if the queue has an item to process. in case exit the for loop
 		# but only if there is no processing of an mqtt command like reboot
-		# there we have already a mqueue item and we must pass the waiting time 
+		# there we have already a mqtt_queue item and we must pass the waiting time 
 		if mqtt_command == False:
-			if mqueue.qsize() != 0:
+			if mqtt_queue.qsize() != 0:
 				break
 		create_async_loop().run_until_complete(_async_timer(0.5))
 


### PR DESCRIPTION
Note that this PR has **BREAKING CHANGES**
This is a major update allowing values to be set dynamic via HA.
* There are two new route blocks: `set_boost_injection` and `set_user_xxx`.
  * `set_boost_injection`
With this route, you can set the boost values for time and wattage.
This route is not documented officially and reading the JS source code of the webUI was a bit challenging. Additionally, it seems that not all Solmates offer setting boost parameters. The JS source checks if you can read the settings and if not it blocks changing them. The boost wattage is originally limited to 500W in the JS code but with test made, I was able to set 800W in my code and the solmate accepted it without issues - means on your own risk 😅 
(Managing boost is a total mess because the keys need to be writtenat once, so I needed to remember the former settings and update only the changed ones)
  * `set_user_xxx`
This are 3 routes that define the injection settings.
* Values in HA are now grouped by meaning:
**Sensor**, **Config** and **Diagnose**
* Entities got new names --> **BREAKING**
This was necessary because for ease of identifying entities that have identical names, because of new entities added and because writable entities reference readable entities for auto updates but then need identical names.
  * Internally we have real key names that are used for the communication with the Solmate API and HA key names that need to match for read/write keys.
* Each push on HA to MQTT creates an internal message that is processed to be written - more or less immediately which includes updating the relevant read values afterwards. Means you will see changes when they appear.
* The HA config assembly has been relocated into an own file as this info is quite big now.
* Entities (keys) not available by your setting or by your solmate can be seen but are inaccessible.
* A lot of code improvements and fixes have been made.
* The README and subsequent documents have been updated.

Though things changed may look not that much, it was a "hell of a ride" to get that in and functional.

**Upgrade Path:**
* Stop the automatic start of the Solmate script in HA and reboot - it will not start when HA comes up or stop the script when using systemd.
* Remove all MQTT entries belonging to the Solmate, this includes:
  * All homassistant autoconfig data
  * All data that gets updated regulary
* Update all files and reenable automatic script start.
All info should now be available in MQTT (HA device and MQTT explorer)
* Reassign the new entities when e.g. used in gauges etc
* Important, read the docs if you have used a Riemann Integration to build up sums. There is a note how to update the RI source to a new entity.