### PR TITLE
Add the ability for a spare/replacement Solmate

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -29,6 +29,7 @@ eet_server_uri="wss://sol.eet.energy:9124/"
 
 # credentials accessing the solmate, not server URI dependent
 eet_serial_number="<solmate-serial-number>"
+eet_spare_serial_number="" # omit of leave empty, use only if you have a spare or replacement device
 eet_password="<solmate-password>"
 eet_device_id="<solmate-given-name>"
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Integrate EET SolMate with Homeassistant using MQTT (read AND write!)
   You need to have as prerequisite HA with MQTT setup and a MQTT broker successfully up and running.
   They can and should therefore run on separate hosts/containers and connect to each other as configured.
 
+* **NEW** since version 6: you **can** define an extra serial number for a spare or replacement Solmate.
+
 * **NEW** since version 5: you **can** write back data from HA via MQTT to the Solmate!
 
 * **NEW** since version 4: you **can** run this scripts as [HA Shell Command](https://www.home-assistant.io/integrations/shell_command/).  

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,13 @@
 # Changelog
 
+* With version 6, the following changes have been implemented:
+  * You can now define an extra serial number for a spare or replacement Solmate.\
+    Use the key `eet_spare_serial_number`which is not mandatory but can be set to either empty ("") or a valid Solmate serial number.
+  * Fix OS based envvar handling with respect to name casing:\
+    Envvars are internally converted to lower case.
+
 * With version 5, the following changes have been implemented:
-  * Enable some values to be set.
+  * Enable some values to be set via MQTT like injection or boost.
   * Values in HA are now grouped by meaning:\
     **Sensor**, **Config** and **Diagnose**
   * Entities got new names --> **BREAKING**

--- a/docs/script-components.md
+++ b/docs/script-components.md
@@ -131,7 +131,7 @@ This is informational only and possibly not complete. All routes have as data `{
 9. `shutdown`  
   This route has the following data attributes\
   `{'shut_reboot': 'reboot'}`  (used)\
-  `{'shut_reboot': 'shutdown'}` (not used)
+  `{'shut_reboot': 'shutdown'}` (currently not used)
 10. `set_system_time`  
   This route has a data attribute like `{datetime: n}` where  
   `const e = On()()`, `n = e.utc().format(t)` and `t = "YYYY-MM-DDTHH:mm:ss"` (using javascript as base)
@@ -146,8 +146,9 @@ This is informational only and possibly not complete. All routes have as data `{
     }
     ```
 12. `set_boost_injection`\
-  The opposite of `set_boost_injection` but with two key that MUST be written in one request!\
+  The opposite of `get_boost_injection` but with two keys that MUST be written in one request!\
   Note that EET's original webUI implementation limits the wattage to 500 (I set the limit to 800)
     ```yaml
     {"time": 600, wattage: 500}
-    ``` 
+    ```
+    When writing the pair, boost starts and the timer `remaining_time` counts down. Setting that timer to 0 stops boosting.

--- a/solmate.py
+++ b/solmate.py
@@ -76,6 +76,7 @@ def main():
 		# Initialize websocket
 		smws_conn = smws.connect_to_solmate(merged_config, console_print)
 		response = smws_conn.authenticate()
+
 	except Exception as err:
 		utils.logging('Failed creating connection/authentication to websocket class.', console_print)
 		# wait until the next try, but do it with a full restart


### PR DESCRIPTION
This PR adds the ability do define a SN for a spare or replacement Solmate using the key `eet_spare_serial_number`.

This is important because the original SN will stay and still be used for the entities in HA which means that there is NO change necessary on the HA side! Only authentication is processed with this new key.

Entities in HA need to be unique which is solved by using the original SN...

The key is optional, can be empty, but used if populated with a SN.