### PR TITLE
Doc text fix

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -62,6 +62,7 @@ eet_spare_serial_number=
 
 # entity defaults
 # these are the currently known default keys and values extracted from the solmates webUI.
+# the defaults DO NOT SET the values but define the RANGE if you send data via MQTT.
 # changing wattage is on your own responsibility but is internally limited to 800.
 # note that 'default_boost_set_time' is currently not used, but may changed later.
 # if:

--- a/.env-sample
+++ b/.env-sample
@@ -62,7 +62,7 @@ eet_spare_serial_number=
 
 # entity defaults
 # these are the currently known default keys and values extracted from the solmates webUI.
-# the defaults DO NOT SET the values but define the RANGE if you send data via MQTT.
+# the defaults DO NOT SET the values for the entity but define the RANGE if you send data via MQTT.
 # changing wattage is on your own responsibility but is internally limited to 800.
 # note that 'default_boost_set_time' is currently not used, but may changed later.
 # if:

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
     If the connection was once established, it reconnects automatically.
   * Add the ability for a spare/replacement Solmate. See the `.env-sample` file for more details.
   * Add new optional envvars to define limits. See the `.env-sample` file for more details.
+    These envvars DO NOT SET the values for the entity but define the RANGE if you send data via MQTT.
   * Global envvars are now optional, you can safely remove them from your config except for those
     where you have deviated settings. See the `.env-sample` file for more details.
   * Timer envvars are now optional, you can safely remove them from your config except for those


### PR DESCRIPTION
This is a small doc text fix only and highlights that changing `default_` keys does only set the allowed range but not the value! 