### PR TITLE
Refactor error handling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+* With version 6.2.0, the following changes have been implemented:
+  * There are no new functionalities BUT:\
+    A big refactoring of error handling has been made. Formerly, the program restarted on most of the errors.
+    Now they are covered in an ever true while loop. This is especially true for the websocket (solmate)
+    or mqtt class . This loop is only exited and the program ended hitting ctrl-c, service stop or an error
+    that cant be covered which then is anyways outside the scope. Selecting a minor version jump, because this
+    change is relevant.
+  * The solmate reboot function now respects the above handling and the log shows correct steps.
+  * Due to the new error handling, sent values via MQTT during any websocket connection loss are processed
+    after reconnection. First in, first out.
 * With version 6.1.0, the following changes have been implemented:
   * On special request, the info section now shows the version of this SW (esham).
 * With version 6.0.0, the following changes have been implemented:

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
   * The solmate reboot function now respects the above handling and the log shows correct steps.
   * Due to the new error handling, sent values via MQTT during any websocket connection loss are processed
     after reconnection. First in, first out.
+  * Some internal restructurings, variable improvements and cleanups
 * With version 6.1.0, the following changes have been implemented:
   * On special request, the info section now shows the version of this SW (esham).
 * With version 6.0.0, the following changes have been implemented:

--- a/solmate.py
+++ b/solmate.py
@@ -3,39 +3,21 @@ import os
 import sys
 import json
 import time
-import signal
 import schedule
 from termcolor import colored
 from datetime import datetime
 import solmate_check as check
+import solmate_connect as connect
 import solmate_env as env
-import solmate_mqtt as smmqtt
 import solmate_utils as utils
-import solmate_websocket as smws
 
-# 2024.07
-version = '6.1.0'
-merged_config = {}
+version = '6.2.0'
 
-def print_request_response(route, response):
-	# print response in formatted or unformatted json
-	# note that the route is always printed to the console in color for ease of readability
-
-	# hardcoded, set to 0 to print unformatted as string
-	print_json = 1
-	if print_json == 1:
-		print(colored('\n' + route + ':', 'red'))
-		# ensure_ascii = False escapes characters like <, >, | etc
-		json_formatted_str = json.dumps(response, indent=2, ensure_ascii = False)
-		print(json_formatted_str)
-	else:
-		print(colored(route + ': ', 'red') + str(response))
-
-def query_once_a_day(smws_conn, route, data, merged_config, mqtt, print_response, endpoint):
+def query_once_a_day(smws_conn, route, data, mqtt_conn, print_response, endpoint):
 	# send request but only when triggered by the scheduler
 	# use only for requests with routes that change rarely, more requests can be added
-	utils.logging('Once a day queries called by scheduler.', merged_config)
-	response = smws_conn.query_solmate(route, data, merged_config, mqtt)
+	utils.logging('Once a day queries called by scheduler.')
+	response = smws_conn.query_solmate(route, data)
 	if response != False:
 		if not 'timestamp' in response:
 			# fake a timestamp into the response if not present
@@ -44,141 +26,33 @@ def query_once_a_day(smws_conn, route, data, merged_config, mqtt, print_response
 			# fake an operating_state into the response if not present, the content will be added in mqtt.
 			response['operating_state'] = ''
 		if print_response:
-			print_request_response(route, response)
-		if mqtt:
-			mqtt.send_sensor_update_message(response, endpoint)
-
-def connect_solmate(merged_config):
-
-	try:
-		# Initialize websocket
-		# when en error occurs during connenction we wait 'timer_offline', part of the exception
-		smws_conn = smws.connect_to_solmate(merged_config)
-		# when en error occurs during authentication we wait 'timer_offline', part of the exception
-		# here, most likely redirection errors may occur when connecting to the cloud
-		response = smws_conn.authenticate()
-
-	except Exception:
-		utils.logging('Failed creating connection/authentication to websocket class.', merged_config)
-		# re-raise the source error, it containes all necessary data
-		raise
-
-	# local
-	# check the presense and value for local access
-	# if the solmates subdomain is part of the URI
-	# local can either be true or false
-	if 'eet_local_subdomain' in merged_config:
-		# only if the key is configured
-		# value_if_true if condition else value_if_false
-		local = True if merged_config['eet_local_subdomain'] in merged_config['eet_server_uri'] else False
-	else:
-		local = False
-
-	# online
-	# determine if the system is online
-	# when connected to the cloud, you get an 'online' response
-	# telling that the solmate is also conected to the server 
-	if 'online' in response:
-		online = response['online']
-		local = False
-	# when directly connected to the solmate, there is no response value returned
-	# we have to manually define it because we were able to directly connect
-	else:
-		online = local
-
-	# on startup, log and continue, or restart
-	# note that if during processing the solmate goes offline, the connection closes
-	# and with the automatic restart procedure, we endup in this questionaire here again
-	if online:
-		# solmate is online
-		utils.logging('SolMate is online.', merged_config)
-	else:
-		# solmate is not online
-		utils.logging('Your SolMate is offline.', merged_config)
-		# wait until the next try, but do it with a full restart
-
-	return smws_conn, online, local
-
-def check_routes(merged_config, smws_conn, local):
-
-	# check if we should *only* print the current API info response
-	# eases debugging the current published available routes
-	if merged_config['general_api_info']:
-		response = smws_conn.query_solmate('get_api_info', {}, merged_config)
-		print('\n\'get_api_info\' route info requested: \n')
-		print(json.dumps(response, ensure_ascii=False, indent=2, separators=(',', ': ')))
-		sys.exit()
-
-	# define api routes or behaviours that may not be available depending on the connection
-	api_available = {}
-
-	# the name is if seen 1:1 from the webUI, true | false
-	# some routes ares only available when connected locally but (currently) not via the cloud
-	# check_route returns true if the route exists and false if not
-	api_available['sun2plugHasBoostInjection'] = smws_conn.check_route('get_boost_injection', {})
-	api_available['hasUserSettings'] = smws_conn.check_route('get_injection_settings', {})
-
-	# the shutdown api has never a true response, we need to decide based on former information
-	api_available['shutdown'] = local
-
-	# some routes we know
-	api_available['local'] = local
-
-	return api_available
-
-def connect_mqtt(merged_config, api_available):
-
-	if merged_config['general_use_mqtt']:
-		# initialize and start mqtt
-		try:
-			mqtt = smmqtt.solmate_mqtt(merged_config, api_available)
-			mqtt.init_mqtt_client()
-			# note that signal handling must be done after initializing mqtt
-			# else the handler cant gracefully shutdown mqtt.
-			# use os.kill(os.getpid(), signal.SIGTERM) where necessary to simulate e.g. a sigterm
-			# signal handlers are always executed in the main Python thread of
-			# the main interpreter, even if the signal was received in another thread.
-			# if not otherwise defined, it itself raises a KeyboardInterrupt to make a shutdown here too
-			signal.signal(signal.SIGINT, mqtt.signal_handler_sigint)
-			# ctrl-c
-			signal.signal(signal.SIGTERM, mqtt.signal_handler_sigterm)
-			# sudo systemctl stop eet.solmate.service
-
-		except Exception:
-			# either class initialisation or initializing mqtt failed
-			# in both cases we cant continue and the the program must end
-			raise
-
-	else:
-		mqtt = False
-
-	return mqtt
+			utils.print_request_response(route, response)
+		if mqtt_conn:
+			mqtt_conn.send_sensor_update_message(response, endpoint)
 
 def main(version):
 
 	# get envvars to configure access either from file or from os/docker envvars
-	global merged_config
-	merged_config = env.process_env(version)
+	utils.merged_config = env.process_env(version)
 
-	# get the general program config data
-	print_response = merged_config['general_print_response']
+	print_response = utils.merged_config['general_print_response']
 
 	# initialize colors for output, needed for Windows
 	if sys.platform == 'win32':
 		os.system('color')
 
     # check for package versions because of breaking changes in libraries used
-	check.package_version(merged_config)
+	check.package_version()
 
 	# first validity config check
-	if 'eet_server_uri' not in merged_config.keys():
+	if 'eet_server_uri' not in utils.merged_config.keys():
 		# if the uri key is not present, exit.
-		# if the uri key is present but empty or wrong, the error can and will be catched below
-		utils.logging('\'eet_server_uri\' was not defined in the configuration, exiting.', merged_config)
+		# if the uri key is present but empty or wrong, the error will be catched in the connection
+		utils.logging('\'eet_server_uri\' was not defined in the configuration, exiting.')
 		sys.exit()
 
 	smws_conn = None
-	mqtt = None
+	mqtt_conn = None
 	eet_connected = False
 	mqtt_connected = False
 	job_scheduler = False
@@ -187,19 +61,21 @@ def main(version):
 		# because things can always happen, we check connectivity and establish if not connected
 
 		try:
+			# in case no connection could be established,
+			# the timer value in the error raised defines which timer to use
 			if not eet_connected:
 				# connect and authenticate, don't continue if this fails
-				# in case there is no connection, the timer value defines which timer to use
-				smws_conn, online, local = connect_solmate(merged_config)
+				smws_conn, online, local = connect.connect_solmate()
+
+				# some api's are only available depending on local or cloud connection
+				api_available = connect.check_routes(smws_conn, local)
 				eet_connected = True
-				api_available = check_routes(merged_config, smws_conn, local)
 
 			if not mqtt_connected:
 				# connect and authenticate to mqtt if defined
-				# mqtt can either be false (mqtt not used) or contains the mqtt connection object
-				mqtt = connect_mqtt(merged_config, api_available)
-				# mqtt is now either false (dont use mqtt) or contains the mqtt object
-				# connected says, that technically initialisation was successful
+				# mqtt_conn can either be false (mqtt not used) or contains the mqtt connection object
+				mqtt_conn = connect.connect_mqtt(api_available)
+				# connected says, that technically the initialisation was successful
 				mqtt_connected = True
 
 			# get values from the 'get_solmate_info' route
@@ -211,8 +87,7 @@ def main(version):
 					smws_conn=smws_conn,
 					route='get_solmate_info',
 					data={},
-					merged_config=merged_config,
-					mqtt=mqtt,
+					mqtt_conn=mqtt_conn,
 					print_response=print_response,
 					endpoint='info'
 				)
@@ -226,8 +101,8 @@ def main(version):
 			while True:
 			# loop to continuosly request live values or process commands from mqtt
 
-				if mqtt:
-					# only if mqtt is enabled
+				if mqtt_conn:
+					# only if mqtt is active
 					# process all write requests from the queue initiated by mqtt
 					while utils.mqtt_queue.qsize() != 0:
 						# we have a message from mqtt because a value change or a button being pressed
@@ -240,65 +115,70 @@ def main(version):
 						# special handling for pressing the reboot button
 						# we could also add a shutdown button to shut down the solmate - not implemented so far
 						if route == 'shutdown' and value == 'reboot':
-							response = smws_conn.query_solmate('shutdown', {'shut_reboot': 'reboot'}, merged_config, mqtt)
+							response = smws_conn.query_solmate('shutdown', {'shut_reboot': 'reboot'})
 							# nothing will executed after a reboot command
 							# there will be websocket connection errors due to loss of the connection
 							# setting the mqtt operatring state to normal is done in the exception
 
 						# process all other queue elements
-						response = smws_conn.query_solmate(route, data, merged_config, mqtt)
+						response = smws_conn.query_solmate(route, data)
 						if response:
 							# {'success': True}
 							if list(response.keys())[0] != 'success':
 								#print(route, data, '\n')
 								err = 'Write back to Solmate failed: ' + str(route) + ' ' + str(data)
-								utils.logging(err, merged_config)
+								utils.logging(err)
 								#print('\n')
 
 				# get values from the 'live_values' route
 				# we only expect solmate connection exceptions 
-				response = smws_conn.query_solmate('live_values', {}, merged_config, mqtt)
+				response = smws_conn.query_solmate('live_values', {})
 				if response:
 					if print_response:
-						print_request_response('live_values', response)
-					if mqtt:
-						mqtt.send_sensor_update_message(response, 'live')
+						utils.print_request_response('live_values', response)
+					if mqtt_conn:
+						mqtt_conn.send_sensor_update_message(response, 'live')
 
 				# get values from the 'get_injection_settings' route if the route is available
 				if api_available['hasUserSettings']:
-					response = smws_conn.query_solmate('get_injection_settings', {}, merged_config, mqtt)
+					response = smws_conn.query_solmate('get_injection_settings', {})
 					if response:
 						if print_response:
-							print_request_response('get_injection_settings', response)
-						if mqtt:
-							mqtt.send_sensor_update_message(response, 'get_injection')
+							utils.print_request_response('get_injection_settings', response)
+						if mqtt_conn:
+							mqtt_conn.send_sensor_update_message(response, 'get_injection')
 
 				# get values from the 'get_boost_injection' route if the route is available
 				if api_available['sun2plugHasBoostInjection']:
-					response = smws_conn.query_solmate('get_boost_injection', {}, merged_config, mqtt)
+					response = smws_conn.query_solmate('get_boost_injection', {})
 					if response:
 						if print_response:
-							print_request_response('get_boost_injection', response)
-						if mqtt:
-							mqtt.send_sensor_update_message(response, 'get_boost')
+							utils.print_request_response('get_boost_injection', response)
+						if mqtt_conn:
+							mqtt_conn.send_sensor_update_message(response, 'get_boost')
 
 				# check if there is a pending job due like the 'get_solmate_info'
 				schedule.run_pending()
 
 				# wait for the next round (async, non blocking for any other running background processes)
-				utils.timer_wait(merged_config, 'timer_live')
+				utils.timer_wait('timer_live')
 
 		except Exception as err:
 			# error printing has been done in the solmate/mqtt class
 
 			if len(err.args) == 2:
-				# if there are 2 arguments in the raised error, we know we have raised it
-				# manually and can query the result for further processing
+				# if there are 2 arguments in the raised error, we hope we have raised it
+				# then we can manually query the result for further processing
 				# err.args[0] is the source string returned
 				# err.args[1] is the timer string to be used
-				error_string = err.args[0]
+				error_string = str(err.args[0])
 
-				if mqtt:
+				if error_string not in ['websocket', 'mqtt']:
+					# we always have argument [0] but we do not know if it was us
+					# re-raising so it can be handled outside (most likely to exit)
+					raise
+
+				if mqtt_conn:
 					if route == 'shutdown' and value == 'reboot':
 						# shutdown needs a special timer and not the one coming from the exception
 						# because that one is too short and we would finally end up in timer_offline
@@ -306,10 +186,11 @@ def main(version):
 				else:
 					timer_to_use = err.args[1]
 
-				seconds_to_wait = merged_config[timer_to_use]
-				string = ' - waiting ' + str(seconds_to_wait) + 's' + ' and reconnect.'
+				seconds_to_wait = str(utils.merged_config[timer_to_use])
+				print_string = ' - waiting ' + seconds_to_wait + 's' + ' and reconnect.'
 
 				# for safety, we remove the class object
+				# handle exceptions based on the source
 
 				if error_string == 'websocket':
 					if smws_conn:
@@ -317,24 +198,25 @@ def main(version):
 					eet_connected = False
 					# the scheduler needs to be reset because the conenction object is no longer valid
 					schedule.clear()
-					utils.logging('Websocket connection error' + string, merged_config)
+					utils.logging('Websocket connection error' + print_string)
 					# do not process any queue in the timer as long we reestablish the connection
 					# set optional argument false, defaults to true
 					# note that mqtt may be running but websocket is disconnected
 					# this handling is for safety because one could send data via HA to MQTT
 					# any open queue elements will be processed after reestablishing the connection !
-					utils.timer_wait(merged_config, timer_to_use, False)
-					if mqtt:
+					utils.timer_wait(timer_to_use, False)
+					if mqtt_conn:
 						# after the timer has ended, go back to normal in mqtt
-						mqtt.set_operating_state_normal()
+						mqtt_conn.set_operating_state_normal()
 
 				if error_string == 'mqtt':
 					# this can only come if mqtt is active 
-					if mqtt:
-						mqtt = None
+					if mqtt_conn:
+						mqtt_conn = None
 					mqtt_connected = False
-					utils.logging('MQTT connection error' + string, merged_config)
-					utils.timer_wait(merged_config, timer_to_use)
+					utils.logging('MQTT connection error' + print_string)
+					utils.timer_wait(timer_to_use)
+
 			else:
 				# the error was not one of the catched above and therefore not coverable
 				# re-raising so it can be handled outside (most likely to exit)
@@ -348,18 +230,18 @@ if __name__ == '__main__':
 	except Exception:
 		# an error has happened before successfully getting the envvars in process_env
 		# to avoid running into an error, we define two mandatory envvars for logging, if not present
-		merged_config.setdefault('general_console_print', True)
-		merged_config.setdefault('general_console_timestamp', False)
+		utils.merged_config.setdefault('general_console_print', True)
+		utils.merged_config.setdefault('general_console_timestamp', False)
 		# re-raise the error to be handled
 		raise
 	except KeyboardInterrupt:
 		# avoid printing ^C on the console
 		# \r = carriage return (octal 015)
-		utils.logging('\rInterrupted by keyboard', merged_config)
+		utils.logging('\rInterrupted by keyboard')
 		try:
 			# terminate script by Control-C, exit code = 130
 			sys.exit(130)
 		except SystemExit:
 			os._exit(130)
 	except Exception as err:
-		utils.logging(str(err), merged_config)
+		utils.logging(str(err))

--- a/solmate_check.py
+++ b/solmate_check.py
@@ -3,7 +3,7 @@ import solmate_utils as utils
 import sys
 from importlib import metadata
 
-def package_version(merged_config):
+def package_version():
 	# https://discuss.python.org/t/the-fastest-way-to-make-a-list-of-installed-packages/23175/4
 	# note that due to a "bug" in the importlib version in python 3.9,
 	# we cant list installed packages, we can only query them if known.
@@ -12,7 +12,7 @@ def package_version(merged_config):
 	# because of breaking changes from 1 --> 2
 	version = semver.Version.parse(metadata.version('paho-mqtt'))
 	if version.major != 2:
-		utils.logging('The paho-mqtt client must be major version 2, check the requirements in README.md, exiting.', merged_config)
+		utils.logging('The paho-mqtt client must be major version 2, check the requirements in README.md, exiting.')
 		sys.exit()
 
 	# if required, add other package version queries

--- a/solmate_connect.py
+++ b/solmate_connect.py
@@ -1,0 +1,113 @@
+import signal
+import solmate_mqtt as smmqtt
+import solmate_utils as utils
+import solmate_websocket as smws
+
+# code that connects to the respective classes and returns the connection object
+# return solmate connection dependent api routes
+
+def connect_solmate():
+
+	try:
+		# Initialize websocket
+		# when en error occurs during connenction we wait 'timer_offline', part of the exception
+		smws_conn = smws.connect_to_solmate()
+		# when en error occurs during authentication we wait 'timer_offline', part of the exception
+		# here, most likely redirection errors may occur when connecting to the cloud
+		response = smws_conn.authenticate()
+
+	except Exception:
+		utils.logging('Failed creating connection/authentication to websocket class.')
+		# re-raise the source error, it containes all necessary data
+		raise
+
+	# local
+	# check the presense and value for local access
+	# if the solmates subdomain is part of the URI
+	# local can either be true or false
+	if 'eet_local_subdomain' in utils.merged_config:
+		# only if the key is configured
+		# value_if_true if condition else value_if_false
+		local = True if utils.merged_config['eet_local_subdomain'] in utils.merged_config['eet_server_uri'] else False
+	else:
+		local = False
+
+	# online
+	# determine if the system is online
+	# when connected to the cloud, you get an 'online' response
+	# telling that the solmate is also conected to the server 
+	if 'online' in response:
+		online = response['online']
+		local = False
+	# when directly connected to the solmate, there is no response value returned
+	# we have to manually define it because we were able to directly connect
+	else:
+		online = local
+
+	# on startup, log and continue, or restart
+	# note that if during processing the solmate goes offline, the connection closes
+	# and with the automatic restart procedure, we endup in this questionaire here again
+	if online:
+		# solmate is online
+		utils.logging('SolMate is online.')
+	else:
+		# solmate is not online
+		utils.logging('Your SolMate is offline.')
+		# wait until the next try, but do it with a full restart
+
+	return smws_conn, online, local
+
+def connect_mqtt(api_available):
+
+	if utils.merged_config['general_use_mqtt']:
+		# initialize and start mqtt
+		try:
+			mqtt_conn = smmqtt.solmate_mqtt(api_available)
+			mqtt_conn.init_mqtt_client()
+			# note that signal handling must be done after initializing mqtt
+			# else the handler cant gracefully shutdown mqtt.
+			# use os.kill(os.getpid(), signal.SIGTERM) where necessary to simulate e.g. a sigterm
+			# signal handlers are always executed in the main Python thread of
+			# the main interpreter, even if the signal was received in another thread.
+			# if not otherwise defined, it itself raises a KeyboardInterrupt to make a shutdown here too
+			signal.signal(signal.SIGINT, mqtt_conn.signal_handler_sigint)
+			# ctrl-c
+			signal.signal(signal.SIGTERM, mqtt_conn.signal_handler_sigterm)
+			# sudo systemctl stop eet.solmate.service
+
+		except Exception:
+			# either class initialisation or initializing mqtt failed
+			# in both cases we cant continue and the the program must end
+			raise
+
+	else:
+		mqtt_conn = False
+
+	return mqtt_conn
+
+def check_routes(smws_conn, local):
+
+	# check if we should *only* print the current API info response
+	# eases debugging the current published available routes
+	if utils.merged_config['general_api_info']:
+		response = smws_conn.query_solmate('get_api_info', {})
+		print('\n\'get_api_info\' route info requested: \n')
+		print(json.dumps(response, ensure_ascii=False, indent=2, separators=(',', ': ')))
+		sys.exit()
+
+	# define api routes or behaviours that may not be available depending on the connection
+	api_available = {}
+
+	# the name is if seen 1:1 from the webUI, true | false
+	# some routes ares only available when connected locally but (currently) not via the cloud
+	# check_route returns true if the route exists and false if not
+	api_available['sun2plugHasBoostInjection'] = smws_conn.check_route('get_boost_injection', {})
+	api_available['hasUserSettings'] = smws_conn.check_route('get_injection_settings', {})
+
+	# the shutdown api has never a true response, we need to decide based on former information
+	api_available['shutdown'] = local
+
+	# some routes we know
+	api_available['local'] = local
+
+	return api_available

--- a/solmate_env.py
+++ b/solmate_env.py
@@ -136,6 +136,10 @@ def _add_optional_env(version):
 	add_optional.setdefault('timer_conn_err', 10)
 	add_optional.setdefault('timer_live', 30)
 	add_optional.setdefault('timer_reboot', 180)
+	add_optional.setdefault('timer_attempt_restart', 3)
+	# add an internal only zero value timer = no waiting time
+	# not exposed to .env-sample
+	add_optional.setdefault('timer_zero', 0)
 
 	# these are the currently known default values extracted from the webUI
 	add_optional.setdefault('default_boost_set_time', 600)

--- a/solmate_env.py
+++ b/solmate_env.py
@@ -137,9 +137,9 @@ def _add_optional_env(version):
 	add_optional.setdefault('timer_live', 30)
 	add_optional.setdefault('timer_reboot', 180)
 	add_optional.setdefault('timer_attempt_restart', 3)
-	# add an internal only zero value timer = no waiting time
+	# add an internal only 1s value timer
 	# not exposed to .env-sample
-	add_optional.setdefault('timer_zero', 0)
+	add_optional.setdefault('timer_min', 1)
 
 	# these are the currently known default values extracted from the webUI
 	add_optional.setdefault('default_boost_set_time', 600)

--- a/solmate_ha_config.py
+++ b/solmate_ha_config.py
@@ -1,4 +1,5 @@
 import json
+import solmate_utils as utils
 
 # the ha config setup is quite big so it is defined in an own file making mqtt better readable.
 # the init parameters from 'self' are handed over and used as 'c_s'
@@ -28,14 +29,14 @@ def construct_ha_config_message(c_s):
 
 	# note that device_values must be populated
 	device_values = {}
-	device_values['identifiers'] = c_s.merged_config['mqtt_topic'] + '_' + c_s.merged_config['eet_serial_number'] # ['eet_solmate']
-	device_values['name'] = c_s.merged_config['mqtt_topic'] #'SOLMATE'
+	device_values['identifiers'] = utils.merged_config['mqtt_topic'] + '_' + utils.merged_config['eet_serial_number'] # ['eet_solmate']
+	device_values['name'] = utils.merged_config['mqtt_topic'] #'SOLMATE'
 	device_values['model'] = 'SOLMATE G'
 	device_values['manufacturer'] = 'EET Energy'
-	device_values['serial_number'] = c_s.merged_config['eet_serial_number']
+	device_values['serial_number'] = utils.merged_config['eet_serial_number']
 
-	if c_s.merged_config['eet_spare_serial_number']:
-		device_values['via_device'] = c_s.merged_config['eet_spare_serial_number']
+	if utils.merged_config['eet_spare_serial_number']:
+		device_values['via_device'] = utils.merged_config['eet_spare_serial_number']
 
 	# virtual topics
 	live = '/live'
@@ -70,7 +71,7 @@ def construct_ha_config_message(c_s):
 		'state_topic': c_s.mqtt_sensor_topic + live,
 		'value_template': '{{ (value_json.' + fake_names[i] + " | as_timestamp()) | timestamp_custom('%Y-%m-%d %H:%M:%S') }}",
 		'availability_topic': c_s.mqtt_availability_topic,
-		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'unique_id': utils.merged_config['eet_serial_number'] + '_' + name,
 		'device': device_values,
 		'icon': 'mdi:progress-clock',
 		'retain': True
@@ -95,7 +96,7 @@ def construct_ha_config_message(c_s):
 		'device_class': 'power',
 		'state_topic': c_s.mqtt_sensor_topic + live,
 		'value_template': '{{ (value_json.' + fake_names[i] + ' | float(0)) | round(1) }}',
-		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'unique_id': utils.merged_config['eet_serial_number'] + '_' + name,
 		'availability_topic': c_s.mqtt_availability_topic,
 		'unit_of_measurement': 'W',
 		'device': device_values,
@@ -122,7 +123,7 @@ def construct_ha_config_message(c_s):
 	'device_class': 'power',
 	'state_topic': c_s.mqtt_sensor_topic + live,
 	'value_template': '{{ (value_json.' + fake_names[i] + ' | float(0)) | round(1) }}',
-	'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+	'unique_id': utils.merged_config['eet_serial_number'] + '_' + name,
 	'availability_topic': c_s.mqtt_availability_topic,
 	'unit_of_measurement': 'W',
 	'device': device_values,
@@ -149,7 +150,7 @@ def construct_ha_config_message(c_s):
 		'device_class': 'power',
 		'state_topic': c_s.mqtt_sensor_topic + live,
 		'value_template': '{{ (value_json.' + fake_names[i] + ' | float(0)) | round(1) }}',
-		'unique_id':c_s.merged_config['eet_serial_number'] + '_' + name,
+		'unique_id': utils.merged_config['eet_serial_number'] + '_' + name,
 		'availability_topic': c_s.mqtt_availability_topic,
 		'unit_of_measurement': 'W',
 		'device': device_values,
@@ -175,7 +176,7 @@ def construct_ha_config_message(c_s):
 		'name': name,
 		'state_topic': c_s.mqtt_sensor_topic + live,
 		'value_template': '{{ ((value_json.' + fake_names[i] + ' | float(0)) * 100) | round(1) }}',
-		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'unique_id': utils.merged_config['eet_serial_number'] + '_' + name,
 		'availability_topic': c_s.mqtt_availability_topic,
 		'unit_of_measurement': '%',
 		'device': device_values,
@@ -202,7 +203,7 @@ def construct_ha_config_message(c_s):
 		'device_class': 'temperature',
 		'state_topic': c_s.mqtt_sensor_topic + live,
 		'value_template': '{{ (value_json.' + fake_names[i] + ' | float(0)) | round(1) }}',
-		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'unique_id': utils.merged_config['eet_serial_number'] + '_' + name,
 		'availability_topic': c_s.mqtt_availability_topic,
 		'unit_of_measurement': '°C',
 		'device': device_values,
@@ -228,7 +229,7 @@ def construct_ha_config_message(c_s):
 		'device_class': 'current',
 		'state_topic': c_s.mqtt_sensor_topic + live,
 		'value_template': '{{ (value_json.' + fake_names[i] + ' | float(0)) | round(2) }}',
-		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'unique_id': utils.merged_config['eet_serial_number'] + '_' + name,
 		'availability_topic': c_s.mqtt_availability_topic,
 		'device': device_values,
 		'unit_of_measurement': 'A',
@@ -256,7 +257,7 @@ def construct_ha_config_message(c_s):
 		# no device class here as it is a string
 		'state_topic': c_s.mqtt_sensor_topic + info,
 		'value_template': '{{ value_json.' + fake_names[i] + ' | version }}',
-		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'unique_id': utils.merged_config['eet_serial_number'] + '_' + name,
 		'availability_topic': c_s.mqtt_availability_topic,
 		'device': device_values,
 		'entity_category': 'diagnostic',
@@ -283,7 +284,7 @@ def construct_ha_config_message(c_s):
 		# no device class here as it is a string
 		'state_topic': c_s.mqtt_sensor_topic + info,
 		'value_template': '{{ value_json.' + fake_names[i] + ' }}',
-		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'unique_id': utils.merged_config['eet_serial_number'] + '_' + name,
 		'availability_topic': c_s.mqtt_availability_topic,
 		'device': device_values,
 		'entity_category': 'diagnostic',
@@ -312,7 +313,7 @@ def construct_ha_config_message(c_s):
 		'state_topic': c_s.mqtt_sensor_topic + info,
 		'value_template': '{{ (value_json.' + fake_names[i] + " | as_timestamp()) | timestamp_custom('%Y-%m-%d %H:%M:%S') }}",
 		'availability_topic': c_s.mqtt_availability_topic,
-		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'unique_id': utils.merged_config['eet_serial_number'] + '_' + name,
 		'device': device_values,
 		'entity_category': 'diagnostic',
 		'icon': 'mdi:clock-time-ten',
@@ -338,7 +339,7 @@ def construct_ha_config_message(c_s):
 		# no device class here as it is a string
 		'state_topic': c_s.mqtt_sensor_topic + info,
 		'value_template': '{{ value_json.' + fake_names[i] + ' }}',
-		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'unique_id': utils.merged_config['eet_serial_number'] + '_' + name,
 		'availability_topic': c_s.mqtt_availability_topic,
 		'device': device_values,
 		'entity_category': 'diagnostic',
@@ -365,7 +366,7 @@ def construct_ha_config_message(c_s):
 		# no device class here as it is a string
 		'state_topic': c_s.mqtt_sensor_topic + info,
 		'value_template': '{{ value_json.' + fake_names[i] + ' }}',
-		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'unique_id': utils.merged_config['eet_serial_number'] + '_' + name,
 		'availability_topic': c_s.mqtt_availability_topic,
 		'device': device_values,
 		'entity_category': 'diagnostic',
@@ -392,7 +393,7 @@ def construct_ha_config_message(c_s):
 		# no device class here as it is a string
 		'state_topic': c_s.mqtt_sensor_topic + info,
 		'value_template': '{{ value_json.' + fake_names[i] + ' }}',
-		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'unique_id': utils.merged_config['eet_serial_number'] + '_' + name,
 		'availability_topic': c_s.mqtt_availability_topic,
 		'device': device_values,
 		'entity_category': 'diagnostic',
@@ -421,7 +422,7 @@ def construct_ha_config_message(c_s):
 		'name': name,
 		'command_topic': c_s.mqtt_button_topic + '/command/' + fake_names[i],
 		'availability_topic': dynamic_topic,
-		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'unique_id': utils.merged_config['eet_serial_number'] + '_' + name,
 		'value_template': '{{ value_json.' + fake_names[i] + ' }}',
 		'device': device_values,
 		'entity_category': 'config',
@@ -453,7 +454,7 @@ def construct_ha_config_message(c_s):
 		'device_class': 'power',
 		'state_topic': c_s.mqtt_sensor_topic + get_injection,
 		'value_template': '{{ (value_json.' + fake_names[i] + ' | float(0)) | round(1) }}',
-		'unique_id':c_s.merged_config['eet_serial_number'] + '_' + name,
+		'unique_id':utils.merged_config['eet_serial_number'] + '_' + name,
 		'availability_topic': dynamic_topic,
 		'unit_of_measurement': 'W',
 		'device': device_values,
@@ -480,7 +481,7 @@ def construct_ha_config_message(c_s):
 		'device_class': 'power',
 		'state_topic': c_s.mqtt_sensor_topic + get_injection,
 		'value_template': '{{ (value_json.' + fake_names[i] + ' | float(0)) | round(1) }}',
-		'unique_id':c_s.merged_config['eet_serial_number'] + '_' + name,
+		'unique_id':utils.merged_config['eet_serial_number'] + '_' + name,
 		'availability_topic': dynamic_topic,
 		'unit_of_measurement': 'W',
 		'device': device_values,
@@ -506,7 +507,7 @@ def construct_ha_config_message(c_s):
 		'name': name,
 		'state_topic': c_s.mqtt_sensor_topic + get_injection,
 		'value_template': '{{ ((value_json.' + fake_names[i] + ' | float(0)) | round(1)) }}',
-		'unique_id': c_s.merged_config['eet_serial_number'] + '_' + name,
+		'unique_id': utils.merged_config['eet_serial_number'] + '_' + name,
 		'availability_topic': dynamic_topic,
 		'unit_of_measurement': '%',
 		'device': device_values,
@@ -538,7 +539,7 @@ def construct_ha_config_message(c_s):
 		'availability_topic': dynamic_topic,
 		'unit_of_measurement': 's',
 		# the name used can be read and written, so we need to distinguish
-		'unique_id':c_s.merged_config['eet_serial_number'] + '_read_' + name,
+		'unique_id':utils.merged_config['eet_serial_number'] + '_read_' + name,
 		'device': device_values,
 		'icon': 'mdi:timer-play-outline',
 		'retain': True
@@ -564,7 +565,7 @@ def construct_ha_config_message(c_s):
 		'state_topic': c_s.mqtt_sensor_topic + get_boost,
 		'value_template': '{{ (value_json.' + fake_names[i] + ' | float(0)) | round(1) }}',
 		# the name used can be read and written, so we need to distinguish
-		'unique_id':c_s.merged_config['eet_serial_number'] + '_read_' + name,
+		'unique_id': utils.merged_config['eet_serial_number'] + '_read_' + name,
 		'availability_topic': dynamic_topic,
 		'unit_of_measurement': 'W',
 		'device': device_values,
@@ -592,7 +593,7 @@ def construct_ha_config_message(c_s):
 		'value_template': '{{ value_json.' + fake_names[i] + ' | int(0) }}',
 		'availability_topic': dynamic_topic,
 		'unit_of_measurement': 's',
-		'unique_id':c_s.merged_config['eet_serial_number'] + '_' + name,
+		'unique_id': utils.merged_config['eet_serial_number'] + '_' + name,
 		'device': device_values,
 		'icon': 'mdi:av-timer',
 		'retain': True
@@ -617,7 +618,7 @@ def construct_ha_config_message(c_s):
 		'device_class': 'power',
 		'state_topic': c_s.mqtt_sensor_topic + get_boost,
 		'value_template': '{{ (value_json.' + fake_names[i] + ' | float(0)) | round(1) }}',
-		'unique_id':c_s.merged_config['eet_serial_number'] + '_' + name,
+		'unique_id': utils.merged_config['eet_serial_number'] + '_' + name,
 		'availability_topic': dynamic_topic,
 		'unit_of_measurement': 'W',
 		'device': device_values,
@@ -645,7 +646,7 @@ def construct_ha_config_message(c_s):
 	dictionaries[name] = {
 		'name': name,
 		'entity_category': 'config',
-		'max': c_s.merged_config['default_boost_injection_wattage'],
+		'max': utils.merged_config['default_boost_injection_wattage'],
 		'min': 0, # hardcoded, see note in solmate_env.py
 		'step': 5,
 		'mode': 'slider',
@@ -653,7 +654,7 @@ def construct_ha_config_message(c_s):
 		'device_class': 'power',
 		'command_topic': c_s.mqtt_number_topic + '/' + fake_names[i],
 		'value_template': '{{ value_json.' + fake_names[i] + ' | int(0) }}',
-		'unique_id':c_s.merged_config['eet_serial_number'] + '_' + name,
+		'unique_id': utils.merged_config['eet_serial_number'] + '_' + name,
 		'availability_topic': dynamic_topic,
 		'unit_of_measurement': 'W',
 		'device': device_values,
@@ -678,14 +679,14 @@ def construct_ha_config_message(c_s):
 	dictionaries[name] = {
 		'name': name,
 		'entity_category': 'config',
-		'max': c_s.merged_config['default_max_boost_time'],
-		'min': c_s.merged_config['default_min_boost_time'],
+		'max': utils.merged_config['default_max_boost_time'],
+		'min': utils.merged_config['default_min_boost_time'],
 		'step': 60,
 		'mode': 'slider',
 		'state_topic': c_s.mqtt_sensor_topic + get_boost,
 		'command_topic': c_s.mqtt_number_topic + '/' + fake_names[i],
 		'value_template': '{{ value_json.' + fake_names[i] + ' | int(0) }}',
-		'unique_id':c_s.merged_config['eet_serial_number'] + '_' + name,
+		'unique_id': utils.merged_config['eet_serial_number'] + '_' + name,
 		'availability_topic': dynamic_topic,
 		'unit_of_measurement': 's',
 		'device': device_values,
@@ -712,7 +713,7 @@ def construct_ha_config_message(c_s):
 	dictionaries[name] = {
 		'name': name,
 		'entity_category': 'config',
-		'max': c_s.merged_config['default_user_maximum_injection'],
+		'max': utils.merged_config['default_user_maximum_injection'],
 		'min': 0,
 		'step': 5,
 		'mode': 'slider',
@@ -720,7 +721,7 @@ def construct_ha_config_message(c_s):
 		'device_class': 'power',
 		'command_topic': c_s.mqtt_number_topic + '/' + fake_names[i],
 		'value_template': '{{ value_json.' + fake_names[i] + ' | int(0) }}',
-		'unique_id':c_s.merged_config['eet_serial_number'] + '_' + name,
+		'unique_id': utils.merged_config['eet_serial_number'] + '_' + name,
 		'availability_topic': dynamic_topic,
 		'unit_of_measurement': 'W',
 		'device': device_values,
@@ -745,15 +746,15 @@ def construct_ha_config_message(c_s):
 	dictionaries[name] = {
 		'name': name,
 		'entity_category': 'config',
-		'max': c_s.merged_config['default_user_maximum_injection'],
-		'min': c_s.merged_config['default_user_minimum_injection'],
+		'max': utils.merged_config['default_user_maximum_injection'],
+		'min': utils.merged_config['default_user_minimum_injection'],
 		'step': 5,
 		'mode': 'slider',
 		'state_topic': c_s.mqtt_sensor_topic + get_injection, 
 		'device_class': 'power',
 		'command_topic': c_s.mqtt_number_topic + '/' + fake_names[i],
 		'value_template': '{{ value_json.' + fake_names[i] + ' | int(0) }}',
-		'unique_id':c_s.merged_config['eet_serial_number'] + '_' + name,
+		'unique_id': utils.merged_config['eet_serial_number'] + '_' + name,
 		'availability_topic': dynamic_topic,
 		'unit_of_measurement': 'W',
 		'device': device_values,
@@ -778,14 +779,14 @@ def construct_ha_config_message(c_s):
 	dictionaries[name] = {
 		'name': name,
 		'entity_category': 'config',
-		'max': c_s.merged_config['default_max_battery'], # hardcoded, see note in solmate_env.py
-		'min': c_s.merged_config['default_user_minimum_battery_percentage'],
+		'max': utils.merged_config['default_max_battery'], # hardcoded, see note in solmate_env.py
+		'min': utils.merged_config['default_user_minimum_battery_percentage'],
 		'step': 5,
 		'mode': 'slider',
 		'state_topic': c_s.mqtt_sensor_topic + get_injection, 
 		'command_topic': c_s.mqtt_number_topic + '/' + fake_names[i],
 		'value_template': '{{ value_json.' + fake_names[i] + ' | int(0) }}',
-		'unique_id':c_s.merged_config['eet_serial_number'] + '_' + name,
+		'unique_id': utils.merged_config['eet_serial_number'] + '_' + name,
 		'availability_topic': dynamic_topic,
 		'unit_of_measurement': '%',
 		'device': device_values,

--- a/solmate_utils.py
+++ b/solmate_utils.py
@@ -61,15 +61,11 @@ async def _async_timer(timer_value):
 	# run an async timer
 	await asyncio.sleep(timer_value)
 
-def timer_wait(merged_config, timer_name, add_log = True, mqtt_command = False):
+def timer_wait(merged_config, timer_name, process_queue = True):
 	# wait the number of seconds passed via the name as argument
 
 	# mqtt_queue is defined on the module level
 	global mqtt_queue
-
-	if add_log:
-		# log at all, but decide where
-		logging('Waiting: ' + timer_name + ': ' + str(merged_config[timer_name]) + 's', merged_config)
 
 	# wait, but let other tasks like websocket or mqtt do its backend stuff.
 	# timer.sleep would hard block that
@@ -79,13 +75,16 @@ def timer_wait(merged_config, timer_name, add_log = True, mqtt_command = False):
 	for x in range(merged_config[timer_name] * 2):
 		# check if the queue has an item to process. in case exit the for loop
 		# but only if there is no processing of an mqtt command like reboot
-		# there we have already a mqtt_queue item and we must pass the waiting time 
-		if mqtt_command == False:
+		# there we have already a mqtt_queue item and we must pass the waiting time
+		if process_queue:
+			# if mqtt is not active, there will also never be an element added to the queue
 			if mqtt_queue.qsize() != 0:
 				break
 		create_async_loop().run_until_complete(_async_timer(0.5))
 
 def restart_program(merged_config, counter=0, mqtt=False):
+	# though not longer necessary and used, we keep this function. who knows...
+
 	# this restarts the program like you would have started it manually again
 	# used for events where it is best to start from scratch
 

--- a/solmate_websocket.py
+++ b/solmate_websocket.py
@@ -17,16 +17,15 @@ class connect_to_solmate:
 	websocket = None                            # websocket will be stored here
 	message_id = 0                              # continous message id
 
-	def __init__(self, merged_config):
-		self.merged_config=merged_config
-		self.server_uri = self.merged_config['eet_server_uri']
+	def __init__(self):
+		self.server_uri = utils.merged_config['eet_server_uri']
 		self.count_before_restart = 0
 		self.message_id = 0
 		self.websocket = None
 		# set of mandatory keywords in the query response if the endpoint does not exist
 		self.err_kwds = {'Response:', 'NotImplemetedError'}
 
-		utils.logging('Initializing websocket connection.', self.merged_config)
+		utils.logging('Initializing websocket connection.')
 		self._create_websocket()
 
 	def _redirected_server(self, uri):
@@ -38,7 +37,7 @@ class connect_to_solmate:
 			utils.create_async_loop().run_until_complete(self._create_socket())
 		except Exception as err:
 			# the reason for the exception has been logged already, just exit
-			utils.logging('Websockets error: ' + str(self.server_uri), self.merged_config)
+			utils.logging('Websockets error: ' + str(self.server_uri))
 			raise Exception('websocket', 'timer_offline')
 
 	def _close_websocket(self):
@@ -49,17 +48,17 @@ class connect_to_solmate:
 	async def _create_socket(self):
 		# create a websocket and connect it to the endpoint.
 		try:
-			utils.logging('Create Socket.', self.merged_config)
+			utils.logging('Create Socket.')
 			if self.websocket is not None:
 				await self.websocket.close()
 
 			self.websocket = await websockets.client.connect(self.server_uri)
 			# you may want to add additional connect parameters like 'ping_interval=xxx' and 'ping_timeout=xxx'
 			# see the readme.md file for a possible reason
-			utils.logging('Websocket is connected to: ' + self.server_uri, self.merged_config)
+			utils.logging('Websocket is connected to: ' + self.server_uri)
 		except Exception as err:
-			utils.logging('Websockets error: ' + str(self.server_uri), self.merged_config)
-			utils.logging('Websockets error: ' + str(err) or 'Empty error string returned.', self.merged_config)
+			utils.logging('Websockets error: ' + str(self.server_uri))
+			utils.logging('Websockets error: ' + str(err) or 'Empty error string returned.')
 			raise Exception('websocket', 'timer_offline')
 
 	async def _send_api_request(self, data, silent = False):
@@ -76,12 +75,12 @@ class connect_to_solmate:
 			# when a mandatory option is not sent correctly/at all (route=logs, missing parameter),
 			# solmate just closes the connection instead writing an error response that could be covered
 			# sadly, the error message is not quite helpful as the connection itself was ok
-			utils.logging('WS Request: Connection closed unexpectedly.', self.merged_config)
+			utils.logging('WS Request: Connection closed unexpectedly.')
 			raise ConnectionError('Connection closed unexpectedly.')
 
 		# for all undefined websocket exceptions
 		except Exception as err:
-			utils.logging('Undefined WS error requesting the solmate API: ' + str(err), self.merged_config)
+			utils.logging('Undefined WS error requesting the solmate API: ' + str(err))
 			raise
 
 		# return the response
@@ -93,11 +92,11 @@ class connect_to_solmate:
 			# contains the original websocket error data
 			err = 'Response: ' + str(response['error'])
 			if not silent:
-				utils.logging(err, self.merged_config)
+				utils.logging(err)
 			raise Exception(err)
 		else:
 			err = 'The response did not contain any useful data.'
-			utils.logging(err, self.merged_config)
+			utils.logging(err)
 			raise Exception(err)
 
 	def ws_request(self, route, data, silent = False):
@@ -114,34 +113,35 @@ class connect_to_solmate:
 			# an asyncio event loop is thread-specific
 			# if there is a thread error, access was out of the current thread!
 			# with such an error, we safely reconnect
-			#utils.logging('Error: ' + str(err), self.merged_config)
+			#utils.logging('Error: ' + str(err))
 			raise Exception('websocket', 'timer_conn_err')
 
 	def authenticate(self):
 		# authenticate in the cloud or local with the given serial number, password and device id
+
 		try:
 			# get the serial number to use for authentication
 			# either the normal sn or, if exists and not empty, the spare sn
-			serial_number = self.merged_config['eet_spare_serial_number'] or self.merged_config['eet_serial_number']
+			serial_number = utils.merged_config['eet_spare_serial_number'] or utils.merged_config['eet_serial_number']
 
 			# get the response to the request of the login route using login data
 			# note to expect that the endpoint 'login' exists
-			utils.logging('Authenticating.', self.merged_config)
+			utils.logging('Authenticating.')
 			response = utils.create_async_loop().run_until_complete(self._send_api_request(
 				{
 					'id': self.message_id,
 					'route': 'login',
 					'data': {
 						'serial_num': serial_number,
-						'user_password_hash': base64.encodebytes(hashlib.sha256(self.merged_config['eet_password'].encode()).digest()).decode(),
-						'device_id': self.merged_config['eet_device_id']
+						'user_password_hash': base64.encodebytes(hashlib.sha256(utils.merged_config['eet_password'].encode()).digest()).decode(),
+						'device_id': utils.merged_config['eet_device_id']
 					}
 				}
 			))
 		except Exception as err:
 			# return that authentication failed
-			utils.logging('Authentication to ' + serial_number + ' failed!', self.merged_config)
-			utils.logging(str(err), self.merged_config)
+			utils.logging('Authentication to ' + serial_number + ' failed!')
+			utils.logging(str(err))
 			raise Exception('websocket', 'timer_offline')
 
 		try:
@@ -163,7 +163,7 @@ class connect_to_solmate:
 							'data': {
 								'serial_num': serial_number,
 								'signature': signature,
-								'device_id': self.merged_config['eet_device_id']
+								'device_id': utils.merged_config['eet_device_id']
 							}
 						}
 					))
@@ -171,7 +171,7 @@ class connect_to_solmate:
 					# if there is a load-balancer handle a redirect
 					if 'redirect' in response and response['redirect'] is not None:
 						redirect_uri = str(response['redirect'])
-						utils.logging('Got redirected to: ' + redirect_uri, self.merged_config)
+						utils.logging('Got redirected to: ' + redirect_uri)
 						self._redirected_server(redirect_uri)
 						utils.create_async_loop().run_until_complete(self._create_socket())
 					else:
@@ -179,14 +179,14 @@ class connect_to_solmate:
 						correct_server = True
 
 				# return the authenticated connection
-				utils.logging('Authentication to ' + serial_number + ' successful!', self.merged_config)
+				utils.logging('Authentication to ' + serial_number + ' successful!')
 				return response
 
 		except Exception as err:
 			# authentication failed
 			# the reason may be bad credentials or a failure when redirecting
-			utils.logging('Authentication to ' + serial_number + ' failed!', self.merged_config)
-			utils.logging(str(err), self.merged_config)
+			utils.logging('Authentication to ' + serial_number + ' failed!')
+			utils.logging(str(err))
 			raise Exception('websocket', 'timer_offline')
 
 	def check_route(self, route, data):
@@ -201,7 +201,7 @@ class connect_to_solmate:
 			# return false if not
 			return False
 
-	def query_solmate(self, route, data, merged_config, mqtt = False):
+	def query_solmate(self, route, data):
 		# send request for the given route including error handling
 
 		try: 
@@ -224,25 +224,26 @@ class connect_to_solmate:
 				# check if both keywords exist in the error message
 				# in case, stop script if the endpoint does not exists, continue makes no sense
 				# logging of which inexistent route was already done in '_send_api_request'
-				utils.logging('Exiting.', self.merged_config)
+				utils.logging('Exiting.')
 				sys.exit()
 
-			if 'sent 1011 (unexpected error) keepalive ping timeout' in str(err):
+			if 'sent 1011' in str(err):
+				# the full string is: 'sent 1011 (unexpected error) keepalive ping timeout'
 				# the endpoint existed, but the response was malformed
 				# the websocket keep alive ping/pong failed (see readme.md)
 				# for an immediately restart we need to implement a new timer with value 0 (or 1)
-				utils.logging('Keep alive ping/pong failed.', self.merged_config)
-				raise Exception('websocket', 'timer_zero')
+				utils.logging('Keep alive ping/pong failed.')
+				raise Exception('websocket', 'timer_min')
 
 			self.count_before_restart += 1
 
-			if self.count_before_restart == merged_config['timer_attempt_restart']:
+			if self.count_before_restart == utils.merged_config['timer_attempt_restart']:
 				# only on _consecutive_ unidentified issues
 				# if waiting the response time did not help, restart after the n-th try 
-				utils.logging('Too many failed consecutive connection attempts: ' + str(self.count_before_restart), self.merged_config)
+				utils.logging('Too many failed consecutive connection attempts: ' + str(self.count_before_restart), utils.merged_config)
 				raise Exception('websocket', 'timer_conn_err')
 
-			utils.logging('A non breaking error happened, continuing.', self.merged_config)
-			#utils.logging('Error: ' + str(err), self.merged_config)
+			utils.logging('A non breaking error happened, continuing.')
+			#utils.logging('Error: ' + str(err))
 			# the false response tells the caller about the incident, it is handled there
 			return False

--- a/solmate_websocket.py
+++ b/solmate_websocket.py
@@ -36,15 +36,20 @@ class connect_to_solmate:
 		# create and connect to websocket
 		try:
 			utils.create_async_loop().run_until_complete(self._create_socket())
-		except Exception:
+		except Exception as err:
 			# the reason for the exception has been logged already, just exit
-			raise
+			utils.logging('Websockets error: ' + str(self.server_uri), self.merged_config)
+			raise Exception('websocket', 'timer_offline')
+
+	def _close_websocket(self):
+		# needed for example when redirected
+		if self.websocket is not None:
+			self.websocket.close()
 
 	async def _create_socket(self):
 		# create a websocket and connect it to the endpoint.
 		try:
 			utils.logging('Create Socket.', self.merged_config)
-			# needed when redirected for example
 			if self.websocket is not None:
 				await self.websocket.close()
 
@@ -55,7 +60,7 @@ class connect_to_solmate:
 		except Exception as err:
 			utils.logging('Websockets error: ' + str(self.server_uri), self.merged_config)
 			utils.logging('Websockets error: ' + str(err) or 'Empty error string returned.', self.merged_config)
-			raise
+			raise Exception('websocket', 'timer_offline')
 
 	async def _send_api_request(self, data, silent = False):
 		# send an api request with the given data and return response data.
@@ -88,11 +93,11 @@ class connect_to_solmate:
 			# contains the original websocket error data
 			err = 'Response: ' + str(response['error'])
 			if not silent:
-				utils.logging(str(err), self.merged_config)
+				utils.logging(err, self.merged_config)
 			raise Exception(err)
 		else:
 			err = 'The response did not contain any useful data.'
-			utils.logging(str(err), self.merged_config)
+			utils.logging(err, self.merged_config)
 			raise Exception(err)
 
 	def ws_request(self, route, data, silent = False):
@@ -105,21 +110,21 @@ class connect_to_solmate:
 			)
 			return response
 
-		except RuntimeError as err:
+		except Exception as err:
 			# an asyncio event loop is thread-specific
 			# if there is a thread error, access was out of the current thread!
-			# with such an error, we safely restart the program
-			utils.logging('Error: ' + str(err), self.merged_config)
-			utils.restart_program(self.merged_config, 0, mqtt)
+			# with such an error, we safely reconnect
+			#utils.logging('Error: ' + str(err), self.merged_config)
+			raise Exception('websocket', 'timer_conn_err')
 
 	def authenticate(self):
-		# authenticate in the cloud or solmate with the given serial number, password and device id
+		# authenticate in the cloud or local with the given serial number, password and device id
 		try:
 			# get the serial number to use for authentication
 			# either the normal sn or, if exists and not empty, the spare sn
 			serial_number = self.merged_config['eet_spare_serial_number'] or self.merged_config['eet_serial_number']
 
-			# get the response to the request of the login route with the login data
+			# get the response to the request of the login route using login data
 			# note to expect that the endpoint 'login' exists
 			utils.logging('Authenticating.', self.merged_config)
 			response = utils.create_async_loop().run_until_complete(self._send_api_request(
@@ -133,14 +138,21 @@ class connect_to_solmate:
 					}
 				}
 			))
+		except Exception as err:
+			# return that authentication failed
+			utils.logging('Authentication to ' + serial_number + ' failed!', self.merged_config)
+			utils.logging(str(err), self.merged_config)
+			raise Exception('websocket', 'timer_offline')
 
+		try:
 			# if login was successful, get the hash to use for authenticated requests
+			# check if we are local or cloud which needs a redirected authentication
 			if 'success' in response and response['success'] and 'signature' in response:
 				# Get the signature for the session to be reused for the next step instead of the password
 				signature = response['signature']
 
 				# check if Server redirects to another instance
-				# (on first connect, the connenction is established to a load-balancer)
+				# (on first connect, the connenction is established to a load-balancer when using the cloud)
 				correct_server = False
 				while not correct_server:
 					# get the response to the authentication route with the authentication data
@@ -156,7 +168,7 @@ class connect_to_solmate:
 						}
 					))
 
-					# handle load-balancer redirect, if there is one
+					# if there is a load-balancer handle a redirect
 					if 'redirect' in response and response['redirect'] is not None:
 						redirect_uri = str(response['redirect'])
 						utils.logging('Got redirected to: ' + redirect_uri, self.merged_config)
@@ -170,15 +182,12 @@ class connect_to_solmate:
 				utils.logging('Authentication to ' + serial_number + ' successful!', self.merged_config)
 				return response
 
+		except Exception as err:
 			# authentication failed
 			# the reason may be bad credentials or a failure when redirecting
-			raise
 			utils.logging('Authentication to ' + serial_number + ' failed!', self.merged_config)
-
-		except Exception:
-			# return that authentication failed
-			utils.logging('Authentication to ' + serial_number + ' failed!', self.merged_config)
-			raise
+			utils.logging(str(err), self.merged_config)
+			raise Exception('websocket', 'timer_offline')
 
 	def check_route(self, route, data):
 		# send request for the given route including error handling
@@ -202,11 +211,10 @@ class connect_to_solmate:
 			return response
 
 		except ConnectionError:
-			# if a connection error happened, restart the program after waiting the timer_conn_err time
+			# if a connection error happened, reconnect after waiting timer_conn_err
 			# note that a connection error can also occur when a required parameter is not sent
 			# also see '_send_api_request()'
-			utils.timer_wait(merged_config, 'timer_conn_err', True)
-			utils.restart_program(self.merged_config, 0, mqtt)
+			raise Exception('websocket', 'timer_conn_err')
 
 		except Exception as err:
 			# depending on other exceptions do
@@ -221,19 +229,20 @@ class connect_to_solmate:
 
 			if 'sent 1011 (unexpected error) keepalive ping timeout' in str(err):
 				# the endpoint existed, but the response was malformed
-				# the websocket keep alive ping/pong failed (see readme.md), restart program immediately
+				# the websocket keep alive ping/pong failed (see readme.md)
+				# for an immediately restart we need to implement a new timer with value 0 (or 1)
 				utils.logging('Keep alive ping/pong failed.', self.merged_config)
-				utils.restart_program(self.merged_config, 0, mqtt)
+				raise Exception('websocket', 'timer_zero')
 
 			self.count_before_restart += 1
 
 			if self.count_before_restart == merged_config['timer_attempt_restart']:
 				# only on _consecutive_ unidentified issues
 				# if waiting the response time did not help, restart after the n-th try 
-				utils.logging('Too many failed consecutive request attempts: ' + str(self.count_before_restart), self.merged_config)
-				utils.restart_program(self.merged_config, self.count_before_restart, mqtt)
+				utils.logging('Too many failed consecutive connection attempts: ' + str(self.count_before_restart), self.merged_config)
+				raise Exception('websocket', 'timer_conn_err')
 
-			utils.logging('An non breaking error happened, continuing.', self.merged_config)
-			utils.logging('Error: ' + str(err), self.merged_config)
+			utils.logging('A non breaking error happened, continuing.', self.merged_config)
+			#utils.logging('Error: ' + str(err), self.merged_config)
 			# the false response tells the caller about the incident, it is handled there
 			return False


### PR DESCRIPTION
This PR changes the folowing:

  * There are no new functionalities BUT:\
    A big refactoring of error handling has been made. Formerly, the program restarted on most of the errors. Now they are covered in an ever true while loop. This is especially true for the websocket (solmate) or mqtt class . This loop is only exited and the program ended hitting ctrl-c, service stop or an error that cant be covered which then is anyways outside the scope. Selecting a minor version jump, because this change is relevant.
  * The solmate reboot function now respects the above handling and the log shows correct steps.
  * Due to the new error handling, sent values via MQTT during any websocket connection loss are processed after reconnection. First in, first out.
  * Some internal restructurings, variable improvements and cleanups
