### PR TITLE
fix a legacy leftover

### DIFF
--- a/solmate_env.py
+++ b/solmate_env.py
@@ -36,7 +36,7 @@ def process_env(version):
 	#print(json.dumps(merged_config, indent=2, sort_keys=True))
 
 	if not ok:
-		sol_utils.logging(message, merged_config)
+		sol_utils.logging(message)
 		sys.exit()
 
 	full_config = {


### PR DESCRIPTION
Fixes a legacy leftover when `sol_utils.logging` in getting the envvars.