### PR TITLE
Monitor esham via appdaemon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ testing/
 my_packages/
 __pycache__/
 
+# exclude all appdeamon starter files but not _0
+solmate_appdaemon_*.py
+!solmate_appdaemon_0.py
+
 # from python virtual env
 bin/
 include/

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ calculated in HA (like when using [Node-RED](https://nodered.org).
 	on demand.
 * **Ressource Efficiency**
   * When running, `esham` has a minimum foodprint and a very low CPU usage.
+* **Managing via HA**
+  * When using Appdaemon, you can start and stop `esham` via a HA entity.
 * **Python Versions**
   * Tested and runs with Python 9 to Python 12
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,15 @@
 
 * Future
 
+## [7.1.0] 2024.08.18
+
+* Appdaemon only:
+  * Added the ability to start and stop `esham` via a HA entity.
+    To do so, you need to create a toggle entity manually in HA first, see the "Install via Appdaemon"
+    guide for more details.
+  * Fixed `.gitignore` to allow multi Solmate installations which would have been deleted on upgrade
+    formerly.
+
 ## [7.0.2] 2024.08.04
 
 * Appdaemon only:

--- a/docs/appdaemon.md
+++ b/docs/appdaemon.md
@@ -9,6 +9,7 @@
    * [Configure Appdaemon](#configure-appdaemon)
    * [Configure esham](#configure-esham)
    * [Appdaemon Startup](#appdaemon-startup)
+   * [Start and Stop the App via HA](#start-and-stop-the-app-via-ha)
 
 ## Prerequisite
 
@@ -142,3 +143,27 @@ On successful startup, you can access the Appdaemon admin console via:
 Then go to section `Logs` and select `solmate_0.log`. 
 
 Finally, check that HA shows in MQTT the new Solmate device.
+
+## Start and Stop the App via HA
+
+If you want to stop and start `esham` via an entity in HA via a toggle switch, you need to manually
+create an entity in HA first. If this is not done, nothing breaks...
+
+With the ability to stop/start the `esham` instance via a HA entity, you can e.g. easily reconfigure
+`esham` without bringing Appdaemon down first.
+
+You can generally disable toggle switch management by setting the `monitor_app` variable in the
+`solmate_appdaemon_0` file to `False`. Consequently you can then skip the following procedure.
+
+Note that entity changes are only considered if Appdaemon is running!
+
+Note that for technical reasons, if you shutdown Appdaemon, the entity defined will **NOT** show the
+`off` but the last state of the app. This is out of my control and maybe fixed by Appdaemon once.
+
+**Setup**: \
+To toggle switch `esham`, you just need to add an integration in HA manually. \
+`Settings → Devices & Services → Helpers → Create Helper`. \
+Select the "Toggle (Schalter)" helper (`input_boolean`) and name it: `solmate_appdaemon_0`.
+The name is important and must match the name of the Python file. Use the respective name if you have
+multiple Solmates. For the icon, select `mdi:script-text-play-outline` or any other icon you like.
+When done, restart Appdaemon. You can now stop and restart `esham` via HA.

--- a/solmate_appdaemon_0.py
+++ b/solmate_appdaemon_0.py
@@ -1,6 +1,7 @@
 import os
 import hassapi as hass
 import multiprocessing
+import solmate_appdmonitor as sol_appd_monitor
 import solmate_appdsolmate as sol_appd_solmate
 
 # for multi solmate installations, make the strings unique like '_0' or ...
@@ -9,9 +10,16 @@ import solmate_appdsolmate as sol_appd_solmate
 # note that the names defined must consistently be used in appdaemons definition files
 env_name_appendix = '_0'
 
+# Set this to false if you do not want to monitor this app via HA
+monitor_app = True
+
+# nothing to do, just a global envvar
+sn = None
+
 class Solmate_0(hass.Hass):
 
 	def initialize(self):
+		global sn
 		# help identifying the thread created based on the filename which is unique
 		sn = os.path.splitext(os.path.basename(__file__))[0]
 		#self.log(sn)
@@ -19,7 +27,7 @@ class Solmate_0(hass.Hass):
 		for p in multiprocessing.active_children():
 			# check if this app is already running
 			if sn in p.name:
-				self.log(str(p.name) + ' is already running, skip starting')
+				self.log(str(p.name) + ' is already running, skipping start')
 				break
 		else:
 			# only start if not found active
@@ -30,3 +38,17 @@ class Solmate_0(hass.Hass):
 					name=sn,
 					args=(self, env_name_appendix, sn)
 					).start()
+
+			# start monitoring if set
+			if monitor_app:
+				self.log('Monitoring enabled for ' + sn)
+				# sn is this script name and necessary for process management and entity naming
+				# self.name is the name defined in apps.yaml and necessary for restarting
+				sol_appd_monitor.start_monitoring(self, sn, self.name)
+
+	def terminate(self):
+		global sn
+
+		# the termination function is called when appdaemon is terminated or restarted
+		if monitor_app:
+			sol_appd_monitor.stop_monitoring(sn)

--- a/solmate_appdmonitor.py
+++ b/solmate_appdmonitor.py
@@ -1,0 +1,119 @@
+import multiprocessing
+
+# global variables for that module
+# note that 'iself' is an artifice to manage appdeamon calls easily, see the callback
+# note that platform must include a trailing dot
+iself = None
+solmates_to_monitor = {}
+platform = 'input_boolean.'
+on = 'on'
+off = 'off'
+
+def start_monitoring(self, sn, app_name):
+	# called when initialize() is initiated
+	global iself
+	global solmates_to_monitor
+	global platform	
+
+	if iself is None:
+		# only needs to be defined once
+		iself = self
+
+	# we name the entity for HA by the name of the python script (sn)
+	# which it is also the name of the process to query
+	# but the app name itself to start is defined in apps.yml
+	# script name != app name (usually)
+	# because each script needs it own .env, we also have an own app name
+
+	# add key/value if not exists
+	solmates_to_monitor[sn] = app_name
+
+	entityID = platform + sn
+
+	if not check_if_entity_exists(entityID):
+		# check if the entity exists in HA and log a note if not
+		message  = 'To monitor this Solmate, you need to add an integration in HA manually. '
+		message += 'Settings -> Devices & Services -> Helpers -> Create Helper. '
+		message += 'Select the "Toggle (Schalter)" helper and name it: ' + sn + ' '
+		message += 'For the icon, select mdi:script-text-play-outline or any other you like. '
+		message += 'When done, restart Appdaemon. You can now stop and restart esham via HA/Appdaemon.'
+		iself.log(message)
+		return
+
+	iself.log('Entity: ' + entityID + ' found in HA, start listening')
+
+	# set entity state in HA for the app to be running
+	set_state_for_ha(entityID, on)
+
+	# listen to entity state changes
+	listen_to_ha(entityID)
+
+def stop_monitoring(sn):
+	# called when terminate() is initiated
+	global iself
+	global platform
+	entityID = platform + sn
+
+	# if exists, try to set the switch in HA to off
+	# note that this curently does not work because
+	# AD disconnects from HA before running terminate()
+	# we keep it, it may get fixed or I find another practicable solution
+	entityID = platform + sn
+	if check_if_entity_exists(entityID):
+		set_state_for_ha(entityID, off)
+
+def check_if_entity_exists(entityID):
+	# check if the entity exists in HA
+	global iself
+	return iself.entity_exists(entityID)
+
+def set_state_for_ha(entityID, st):
+	# set the state of the entity in HA to
+	iself.set_state(entityID, state=st)
+
+def listen_to_ha(entityID):
+	# create a listener for the entity
+	# all entities have the same listener
+	global iself
+	iself.listen_state(entity_cb, entityID)
+
+def entity_cb(entity, attribute, old, new, kwargs):
+	# callback for entity changes
+	# the returned entity is the one we take care on
+	# note that an entity returned was fomerly added by the listener
+	global iself
+	global solmates_to_monitor
+	global platform
+
+	#iself.log(f'{entity} {attribute} {old} {new}')
+	sn = entity.replace(platform, '')
+	if 'off' in new:
+		terminate_app(sn)
+	else:
+		# we know that 'solmates_to_monitor' is proper populated and has unique keys
+		# the sn's value defines the app name to start
+		start_app(sn, solmates_to_monitor[sn])
+
+def terminate_app(sn):
+	# terminate the app if running
+	global iself
+	p, found = get_running_state(sn)
+	if found:
+		p.terminate()
+		iself.log(sn + ' has been terminated by request via HA')
+
+def start_app(sn, app_name):
+	# start the app if not running
+	global iself
+	p, found = get_running_state(sn)
+	if not found:
+		iself.restart_app(app_name)
+		iself.log(sn + ' has been started by request via HA')
+
+def get_running_state(sn):
+	# check if this app is running
+	for p in multiprocessing.active_children():
+		if sn in p.name:
+			return p, True
+	else:
+		return False, False

--- a/solmate_appdsolmate.py
+++ b/solmate_appdsolmate.py
@@ -9,19 +9,6 @@ def main(self, env_name_appendix, sn):
 		self.env_name_appendix = env_name_appendix
 		sol_main.main(self)
 
-	except SystemExit:
+	except SystemExit as err:
 		# catch system exit raised by 'sys.exit()'
-		sol_utils.logging('Main: Terminated by the program')
-
-		# also log to appdaemon
-		self.log(sn + ': Got erminated by the program')
-
-# maybe we want to add in the future something like:
-#
-#import multiprocessing
-#for p in multiprocessing.active_children():
-#	if 'solmate_appdaemon' in p.name:
-#		self.log('Found: ' + str(p.name))
-#		p.terminate()
-#		self.log('Terminated: ' + str(p.name))
-
+		sol_utils.logging('Main: Terminated the program')

--- a/solmate_ha_config.py
+++ b/solmate_ha_config.py
@@ -14,7 +14,7 @@ def construct_ha_config_message(c_s):
 	# https://www.home-assistant.io/integrations/sensor.mqtt/
 	# https://www.home-assistant.io/integrations/sensor/#device-class
 	# https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes
-	# https://www.home-assistant.io/docs/configuration/customizing-devices/#icon
+	# https://pictogrammers.com/library/mdi/
 
 	names = ['']			# assembled as '/' + virtual_topic + fake_name
 	fake_names = ['']		# the name used in the mqtt message

--- a/solmate_main.py
+++ b/solmate_main.py
@@ -8,7 +8,7 @@ import solmate_connect as sol_connect
 import solmate_env as sol_env
 import solmate_utils as sol_utils
 
-version = '7.0.2'
+version = '7.1.0'
 
 def query_once_a_day(smws_conn, route, data, mqtt_conn, print_response, endpoint):
 	# send request but only when triggered by the scheduler


### PR DESCRIPTION
* Appdaemon only:
  * Added the ability to start and stop `esham` via a HA entity.
    To do so, you need to create a toggle entity manually in HA first, see the
    "Install via Appdaemon"     guide for more details.
  * Fixed `.gitignore` to allow multi Solmate installations which would have been deleted on upgrade     formerly.