### PR TITLE
Fix edge cases: MQTT backwrite while first initializing is not complete

### DIFF
--- a/solmate_mqtt.py
+++ b/solmate_mqtt.py
@@ -331,6 +331,20 @@ class solmate_mqtt():
 
 		# do not process before a first query run and publishing the results to mqtt has run
 		if not self.first_query_has_run:
+			sol_utils.logging('MQTT: Write back from MQTT before first full query completed, skipping.')
+			return
+
+		# there can be the _very_ rare case that both:
+		# 'remember_get_boost_response' and 'remember_get_injection_response'
+		# can be empty though 'first_query_has_run' is true.
+		# this would lead to a hard error: TypeError: 'NoneType' object is not subscriptable
+		# when trying to access an element inside the variable.
+		# for both cases, do not accept any mqtt backwrites until initialisation is complete
+		if remember_get_boost_response == None:
+			sol_utils.logging('MQTT: Boost response from Solmate not fully initialized, skipping write back.')
+			return
+		if remember_get_injection_response == None:
+			sol_utils.logging('MQTT: Injection response from Solmate not fully initialized, skipping write back.')
 			return
 
 		# triggered on published messages when subscribed


### PR DESCRIPTION
This PR improves/fixes edge cases where there is a:

* backwrite from HA to MQTT before the first initialistation has been completed, 
* or initialisation has been completed but the Solmate did not send a proper response for boost or injection during the regular query

The variables used are then not properly setup for further processing and cause a hard error.

The solution was to check the variable state, log the cause and return, waiting for the next round.

Note, if the Solmate continuosly refuses to send responses for the two variables in question, consecutive log entries are printed and no backwrite from HA via MQTT can be processed - until a response is received.