### PR TITLE
Add unreachable error logging

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@
 
 * Future
 
+## [7.2.4] 2025.04.06
+
+* Added a logging when either the Solmate or the MQTT server cant be reached anymore. This can happen for example on network outages, when the
+  Solmate is offline or is disconnected due to a defect, or the MQTT server is offline. This logging helps to makes it clear where an issue is
+  origined, either on the `esham` side or required hardware is not available.
+
 ## [7.2.3] 2025.03.21
 
 * Fixing of two edge cases that could crash esham:

--- a/solmate_main.py
+++ b/solmate_main.py
@@ -8,7 +8,7 @@ import solmate_connect as sol_connect
 import solmate_env as sol_env
 import solmate_utils as sol_utils
 
-version = '7.2.3'
+version = '7.2.4'
 
 def query_once_a_day(smws_conn, route, data, mqtt_conn, print_response, endpoint):
 	# send request but only when triggered by the scheduler
@@ -214,9 +214,13 @@ def main(self = None):
 					if smws_conn:
 						smws_conn = None
 					eet_connected = False
-					# the scheduler needs to be reset because the conenction object is no longer valid
+					# the scheduler needs to be reset because the connection object is no longer valid
 					schedule.clear()
 					sol_utils.logging('Main: Websocket: Connection error' + print_string)
+					# check if the solmate is reachable
+					host,port = sol_utils.strip_host_port(sol_utils.merged_config['eet_server_uri'])
+					if not sol_utils.isOpen(host, port):
+						sol_utils.logging('Main: No reply from Solmate: ' + str(host) + ':' + str(port))
 					# do not process any queue in the timer as long we reestablish the connection
 					# set optional argument false, defaults to true
 					# note that mqtt may be running but websocket is disconnected
@@ -235,6 +239,11 @@ def main(self = None):
 						mqtt_conn = None
 					mqtt_connected = False
 					sol_utils.logging('Main: MQTT: Connection error' + print_string)
+					# check if the mqtt server is reachable at all
+					host = sol_utils.strip_host_port(sol_utils.merged_config['mqtt_server'])
+					port = sol_utils.merged_config['mqtt_port']
+					if not sol_utils.isOpen(host, port):
+						sol_utils.logging('Main: No reply from MQTT server: ' + str(host) + ':' + str(port))
 					sol_utils.timer_wait(timer_to_use)
 
 			else:

--- a/solmate_mqtt.py
+++ b/solmate_mqtt.py
@@ -84,7 +84,7 @@ class solmate_mqtt():
 		#	eet/solmate/sensor
 		#	homeassistant/solmate/sensor/sensor_name/config
 		#	eet/solmate/sensor/sensor_name/availability
-	
+
 		self.mqtt_button_topic = self.mqtt_prefix + '/button/' + self.mqtt_topic
 		self.mqtt_number_topic = self.mqtt_prefix + '/number/' + self.mqtt_topic
 		self.mqtt_sensor_topic = self.mqtt_prefix + '/sensor/' + self.mqtt_topic
@@ -323,6 +323,11 @@ class solmate_mqtt():
 				+ ', packet: '
 				+ str(PacketTypes.Names[reason_code.packetType])
 				)
+			# check if the mqtt server is reachable at all
+			host,port = sol_utils.strip_host_port(sol_utils.merged_config['mqtt_server'])
+			port = sol_utils.merged_config['mqtt_port']
+			if not sol_utils.isOpen(host, port):
+				sol_utils.logging('Main: No reply from MQTT server: ' + str(host) + ':' + str(port))
 
 	def _on_publish(self, client, userdata, message, reason_codes, properties = None):
 		print(f'MQTT messages published: {message}')


### PR DESCRIPTION
Added a logging when either the Solmate or the MQTT server cant be reached anymore. This can happen for example on network outages, when the Solmate is offline or is disconnected due to a defect, or the MQTT server is offline. This logging helps to makes it clear where an issue is origined, either on the `esham` side or required hardware is not available.