### PR TITLE
Fix missing variable class instance identifyer

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@
 
 * Future
 
+## [7.2.5] 2025.04.10
+
+* Fixed a bug introduced with 7.2.4. Two variables were not using the class instance identifyer.
+
 ## [7.2.4] 2025.04.06
 
 * Added a logging when either the Solmate or the MQTT server cant be reached anymore. This can happen for example on network outages, when the

--- a/solmate_main.py
+++ b/solmate_main.py
@@ -8,7 +8,7 @@ import solmate_connect as sol_connect
 import solmate_env as sol_env
 import solmate_utils as sol_utils
 
-version = '7.2.4'
+version = '7.2.5'
 
 def query_once_a_day(smws_conn, route, data, mqtt_conn, print_response, endpoint):
 	# send request but only when triggered by the scheduler

--- a/solmate_mqtt.py
+++ b/solmate_mqtt.py
@@ -345,10 +345,10 @@ class solmate_mqtt():
 		# this would lead to a hard error: TypeError: 'NoneType' object is not subscriptable
 		# when trying to access an element inside the variable.
 		# for both cases, do not accept any mqtt backwrites until initialisation is complete
-		if remember_get_boost_response == None:
+		if self.remember_get_boost_response == None:
 			sol_utils.logging('MQTT: Boost response from Solmate not fully initialized, skipping write back.')
 			return
-		if remember_get_injection_response == None:
+		if self.remember_get_injection_response == None:
 			sol_utils.logging('MQTT: Injection response from Solmate not fully initialized, skipping write back.')
 			return
 


### PR DESCRIPTION
This PR fixes a bug that was introduced with 7.2.4
Two variables did not use the required class identifer `self` and could cause `esham` to crash with a variable not defined error.